### PR TITLE
fix: 修复审计发现的三个缺陷（close 锁释放 / topK 校验 / unlink 幂等）Fix/audit bugs

### DIFF
--- a/src/bindings/nodejs.rs
+++ b/src/bindings/nodejs.rs
@@ -46,7 +46,8 @@ pub mod nodejs {
     /// 高级管线专用配置结构
     #[napi(object)]
     pub struct JsSearchConfig {
-        pub top_k: Option<u32>,
+        /// top_k 用 i64 承载：u32 会把 JS 负数无符号化成超大值（静默返回全库）
+        pub top_k: Option<i64>,
         pub expand_depth: Option<u32>,
         pub min_score: Option<f64>,
         pub teleport_alpha: Option<f64>,
@@ -242,8 +243,14 @@ pub mod nodejs {
                 diffusion_bias: None,
             });
 
+            let top_k = cfg.top_k.unwrap_or(5);
+            if top_k <= 0 {
+                return Err(napi::Error::from_reason(format!(
+                    "top_k 必须为正整数，收到 {top_k}"
+                )));
+            }
             let core_config = crate::database::SearchConfig {
-                top_k: cfg.top_k.unwrap_or(5) as usize,
+                top_k: top_k as usize,
                 expand_depth: cfg.expand_depth.unwrap_or(2) as usize,
                 min_score: cfg.min_score.unwrap_or(0.1) as f32,
                 teleport_alpha: cfg.teleport_alpha.unwrap_or(0.0) as f32,
@@ -634,11 +641,17 @@ pub mod nodejs {
         pub fn search(
             &self,
             query_vector: Vec<f64>,
-            top_k: Option<u32>,
+            top_k: Option<i64>,
             expand_depth: Option<u32>,
             min_score: Option<f64>,
         ) -> napi::Result<Vec<JsSearchHit>> {
-            let top_k = top_k.unwrap_or(5) as usize;
+            let top_k = top_k.unwrap_or(5);
+            if top_k <= 0 {
+                return Err(napi::Error::from_reason(format!(
+                    "top_k 必须为正整数，收到 {top_k}"
+                )));
+            }
+            let top_k = top_k as usize;
             let expand_depth = expand_depth.unwrap_or(0) as usize;
             let min_score = min_score.unwrap_or(0.5) as f32;
 
@@ -697,8 +710,14 @@ pub mod nodejs {
                 diffusion_bias: None,
             });
 
+            let top_k = cfg.top_k.unwrap_or(5);
+            if top_k <= 0 {
+                return Err(napi::Error::from_reason(format!(
+                    "top_k 必须为正整数，收到 {top_k}"
+                )));
+            }
             let core_config = crate::database::SearchConfig {
-                top_k: cfg.top_k.unwrap_or(5) as usize,
+                top_k: top_k as usize,
                 expand_depth: cfg.expand_depth.unwrap_or(2) as usize,
                 min_score: cfg.min_score.unwrap_or(0.1) as f32,
                 teleport_alpha: cfg.teleport_alpha.unwrap_or(0.0) as f32,
@@ -755,12 +774,18 @@ pub mod nodejs {
             &self,
             query_vector: Vec<f64>,
             query_text: String,
-            top_k: Option<u32>,
+            top_k: Option<i64>,
             expand_depth: Option<u32>,
             min_score: Option<f64>,
             hybrid_alpha: Option<f64>,
         ) -> napi::Result<Vec<JsSearchHit>> {
-            let top_k = top_k.unwrap_or(5) as usize;
+            let top_k = top_k.unwrap_or(5);
+            if top_k <= 0 {
+                return Err(napi::Error::from_reason(format!(
+                    "top_k 必须为正整数，收到 {top_k}"
+                )));
+            }
+            let top_k = top_k as usize;
             let expand_depth = expand_depth.unwrap_or(2) as usize;
             let min_score = min_score.unwrap_or(0.1) as f32;
             let alpha = hybrid_alpha.unwrap_or(0.7) as f32;
@@ -1045,7 +1070,9 @@ pub mod nodejs {
         /// 显式关闭数据库（落盘后释放资源）
         #[napi]
         pub fn close(&mut self) -> napi::Result<()> {
-            self.flush()
+            self.flush()?;
+            dispatch!(self, mut db => db.release_lock());
+            Ok(())
         }
     } // impl TriviumDB
 } // mod nodejs

--- a/src/bindings/python.rs
+++ b/src/bindings/python.rs
@@ -1293,7 +1293,9 @@ pub mod python {
 
         /// 显式关闭数据库（落盘后释放资源）
         fn close(&mut self) -> PyResult<()> {
-            self.flush()
+            self.flush()?;
+            dispatch!(self, mut db => db.release_lock());
+            Ok(())
         }
     }
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -44,7 +44,8 @@ pub struct Database<T: VectorType> {
     pub(crate) wal: Arc<Mutex<Wal>>,
     pub(crate) compaction: Option<CompactionThread>,
     /// 文件锁：防止多进程同时打开同一个数据库
-    _lock_file: std::fs::File,
+    /// Option 化以便 close() 时显式 take 释放（否则锁要等对象 Drop，JS GC 时机不可控）
+    _lock_file: Option<std::fs::File>,
     /// 内存上限（字节），0 = 无限制
     memory_limit: usize,
     /// 存储模式
@@ -164,7 +165,7 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
             memtable: Arc::new(Mutex::new(memtable)),
             wal: Arc::new(Mutex::new(wal)),
             compaction: None,
-            _lock_file: lock_file,
+            _lock_file: Some(lock_file),
             memory_limit: 0,
             storage_mode: config.storage_mode,
             hook: Arc::new(NoopHook),
@@ -912,7 +913,22 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
 
     pub fn close(mut self) -> Result<()> {
         self.disable_auto_compaction();
-        self.flush()
+        let result = self.flush();
+        self.release_lock();
+        result
+    }
+
+    /// 显式释放文件锁并清理 `.lock` 残留文件（幂等）。
+    ///
+    /// 锁句柄持有 OS flock，必须 Drop 后才释放；此前锁一直要等
+    /// `Database` 对象 Drop（JS/Python 绑定下为 GC 时机），导致
+    /// close() 之后同进程无法立即重开同一库文件。此方法把句柄
+    /// take 出来立即 Drop，并清理锁文件。多进程场景下若其他进程
+    /// 仍持有锁，Windows 上删除文件会失败，忽略即可（不影响锁）。
+    pub fn release_lock(&mut self) {
+        self._lock_file.take();
+        let lock_path = format!("{}.lock", self.db_path);
+        let _ = std::fs::remove_file(&lock_path);
     }
 
     pub fn node_count(&self) -> usize {

--- a/src/storage/memtable.rs
+++ b/src/storage/memtable.rs
@@ -422,7 +422,9 @@ impl<T: VectorType> MemTable<T> {
     }
 
     pub(crate) fn validate_unlink(&self, src: NodeId) -> Result<()> {
-        if self.edges.contains_key(&src) {
+        // 幂等语义：只要节点存在即可（edges 表只登记有出边的节点，
+        // src 无出边时断开不存在的边应视为无操作，而非误报 NodeNotFound）。
+        if self.payloads.contains_key(&src) {
             Ok(())
         } else {
             Err(TriviumError::NodeNotFound(src))

--- a/src/storage/memtable.rs
+++ b/src/storage/memtable.rs
@@ -976,7 +976,15 @@ impl<T: VectorType> MemTable<T> {
 
     /// 断开两个节点之间的指定边
     pub fn unlink(&mut self, src: NodeId, dst: NodeId) -> Result<()> {
-        if let Some(edge_list) = self.edges.get_mut(&src) {
+        let Some(edge_list) = self.edges.get_mut(&src) else {
+            // src 没有出边：只要节点本身存在，断开不存在的边应视为幂等无操作，
+            // 而不是误报 NodeNotFound（edges 表只登记有出边的节点）。
+            if self.payloads.contains_key(&src) {
+                return Ok(());
+            }
+            return Err(TriviumError::NodeNotFound(src));
+        };
+        {
             let initial_len = edge_list.len();
             // 先清理 label_index 中对应的条目
             for edge in edge_list.iter() {
@@ -997,8 +1005,6 @@ impl<T: VectorType> MemTable<T> {
                 }
             }
             Ok(())
-        } else {
-            Err(TriviumError::NodeNotFound(src))
         }
     }
 

--- a/tests/engine_deep.rs
+++ b/tests/engine_deep.rs
@@ -561,7 +561,7 @@ fn COV7_20_delete_twice() {
     cleanup(&path);
 }
 
-/// unlink 不存在的边
+/// unlink 不存在边的幂等语义（B4 修复后：节点存在但无出边 → 无操作；节点不存在 → 报错）
 #[test]
 fn COV7_21_unlink_nonexistent() {
     let path = tmp_db("unlink_none");
@@ -574,11 +574,16 @@ fn COV7_21_unlink_nonexistent() {
         .unwrap();
 
     let before = db.node_count();
+    // 节点存在但 src 无出边：幂等成功（不再误报 NodeNotFound）
     let r = db.unlink(id1, id2);
-    assert!(r.is_err(), "不存在的边应安全拒绝");
-    assert_eq!(db.node_count(), before, "unlink 失败不能影响节点数");
+    assert!(r.is_ok(), "存在但无出边的节点 unlink 应幂等成功，实际 {:?}", r);
+    assert_eq!(db.node_count(), before, "unlink 不能影响节点数");
     assert!(db.get_payload(id1).is_some(), "源节点不能被误删");
     assert!(db.get_payload(id2).is_some(), "目标节点不能被误删");
+
+    // 节点不存在：仍应报错
+    let r2 = db.unlink(9999, id1);
+    assert!(r2.is_err(), "不存在的节点 unlink 仍应报错");
 
     cleanup(&path);
 }


### PR DESCRIPTION
## 修复前：审计确认的问题（黑盒实测 v0.7.2 预编译二进制）

| # | 严重度 | 问题 | 根因 |
|---|---|---|---|
| B1 | 中 | close() 后同进程立即重开报 Database locked，.lock 文件残留 | 锁释放依赖 Rust Drop（JS GC 时机），close 只 flush 不释放锁不删文件 |
| B3 | 中 | search 系 topK=0 返回 1 条；topK 负数被 Option<u32> 无符号化成超大值，静默返回全库 | pipeline.rs 的 max(1) 兜底 + u32 无符号化 |
| B4 | 低 | unlink(src,dst) 在 src 无出边时误报 NodeNotFound(src) | edges 表只登记有出边的节点 |

## 修复后：改动说明（commit 3cc76bc + 5d1567f）

- B1：_lock_file Option 化 + release_lock()（take 句柄立即 Drop + 清理 .lock），nodejs/python close() 同步调用
- B3：top_k 参数 Option<u32> → Option<i64>，<=0 返回错误（search / search_hybrid / searchAdvanced / searchWithContext）
- B4：unlink 幂等——节点存在但无出边时 Ok(())；补全 validate_unlink 校验层 + 同步更新 COV7_21 断言

## 验证：修复前后测试对比

JS 黑盒 verify-fixes.js（修复前 → 修复后）：
修复前: PASS=7 FAIL=2（B1 lock 断言时机错误 / B4 幂等被校验层拦截）
修复后: PASS=9 FAIL=0（B1×2 / B3×3 / B4×4 全过）

Rust 全量测试：cargo test --features nodejs 全绿，0 failed（含 282 doc-tests）

## 兼容性
RAG 业务侧（triviumdb-store 连接缓存设计）对三项修复均兼容。

## 备注
B2（d.ts 与运行时不同步）已由 PR #9（84cc7f1）修复，不在本 PR 范围。
