### PR TITLE
fix: 修复 BQ 块长度整数溢出（DoS）与 close 后写操作未拒绝

### DIFF
--- a/src/bindings/python.rs
+++ b/src/bindings/python.rs
@@ -1027,7 +1027,10 @@ pub mod python {
             _exc_val: Option<&Bound<'_, PyAny>>,
             _exc_tb: Option<&Bound<'_, PyAny>>,
         ) -> PyResult<bool> {
+            // 与 close() 对齐：flush 后显式释放文件锁，避免 with 块退出后
+            // 同进程重开报 Database locked
             self.flush()?;
+            dispatch!(self, mut db => db.release_lock());
             Ok(false)
         }
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -46,6 +46,8 @@ pub struct Database<T: VectorType> {
     /// 文件锁：防止多进程同时打开同一个数据库
     /// Option 化以便 close() 时显式 take 释放（否则锁要等对象 Drop，JS GC 时机不可控）
     _lock_file: Option<std::fs::File>,
+    /// 关闭标记：release_lock()/close() 后置位，写操作拒绝（防止释放锁后无保护双写）
+    closed: bool,
     /// 内存上限（字节），0 = 无限制
     memory_limit: usize,
     /// 存储模式
@@ -167,6 +169,7 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
             wal: Arc::new(Mutex::new(wal)),
             compaction: None,
             _lock_file: Some(lock_file),
+            closed: false,
             memory_limit: 0,
             storage_mode: config.storage_mode,
             hook: Arc::new(NoopHook),
@@ -323,6 +326,9 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
 
     /// 主动触发全量重写与压实（Manual Compaction）
     pub fn compact(&mut self) -> Result<()> {
+        if self.closed {
+            return Err(TriviumError::DatabaseClosed);
+        }
         {
             let mut mt = lock_or_recover(&self.memtable);
             tracing::info!("手动压实开始 (Manual compaction started): {}", self.db_path);
@@ -350,6 +356,9 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
     // ════════════════════════════════════════════════════════
 
     pub fn insert(&mut self, vector: &[T], payload: serde_json::Value) -> Result<NodeId> {
+        if self.closed {
+            return Err(TriviumError::DatabaseClosed);
+        }
         let payload_str = payload.to_string();
         if payload_str.len() > 8 * 1024 * 1024 {
             return Err(crate::error::TriviumError::PayloadTooLarge {
@@ -381,6 +390,9 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
         vector: &[T],
         payload: serde_json::Value,
     ) -> Result<()> {
+        if self.closed {
+            return Err(TriviumError::DatabaseClosed);
+        }
         let payload_str = payload.to_string();
         if payload_str.len() > 8 * 1024 * 1024 {
             return Err(crate::error::TriviumError::PayloadTooLarge {
@@ -405,6 +417,9 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
     }
 
     pub fn link(&mut self, src: NodeId, dst: NodeId, label: &str, weight: f32) -> Result<()> {
+        if self.closed {
+            return Err(TriviumError::DatabaseClosed);
+        }
         {
             let mut mt = lock_or_recover(&self.memtable);
             mt.validate_link(src, dst)?;
@@ -421,6 +436,9 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
     }
 
     pub fn delete(&mut self, id: NodeId) -> Result<()> {
+        if self.closed {
+            return Err(TriviumError::DatabaseClosed);
+        }
         {
             let mut mt = lock_or_recover(&self.memtable);
             mt.validate_delete(id)?;
@@ -433,6 +451,9 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
     }
 
     pub fn unlink(&mut self, src: NodeId, dst: NodeId) -> Result<()> {
+        if self.closed {
+            return Err(TriviumError::DatabaseClosed);
+        }
         {
             let mut mt = lock_or_recover(&self.memtable);
             mt.validate_unlink(src)?;
@@ -444,6 +465,9 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
     }
 
     pub fn update_payload(&mut self, id: NodeId, payload: serde_json::Value) -> Result<()> {
+        if self.closed {
+            return Err(TriviumError::DatabaseClosed);
+        }
         let payload_str = payload.to_string();
         if payload_str.len() > 8 * 1024 * 1024 {
             return Err(crate::error::TriviumError::PayloadTooLarge {
@@ -481,6 +505,9 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
     /// db.patch_payload(id, serde_json::json!({"name": "Bob"}))?;
     /// ```
     pub fn patch_payload(&mut self, id: NodeId, patch: serde_json::Value) -> Result<()> {
+        if self.closed {
+            return Err(TriviumError::DatabaseClosed);
+        }
         let final_payload = {
             let mt = lock_or_recover(&self.memtable);
             mt.preview_patch_payload(id, &patch)?
@@ -507,6 +534,9 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
     }
 
     pub fn update_vector(&mut self, id: NodeId, vector: &[T]) -> Result<()> {
+        if self.closed {
+            return Err(TriviumError::DatabaseClosed);
+        }
         {
             let mut mt = lock_or_recover(&self.memtable);
             mt.validate_update_vector(id, vector)?;
@@ -915,6 +945,9 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
     ///   1. 原子写入 .tdb（写 .tmp → fsync → rename）
     ///   2. 确认 .tdb 写入成功后，才清除 WAL
     pub fn flush(&mut self) -> Result<()> {
+        if self.closed {
+            return Err(TriviumError::DatabaseClosed);
+        }
         {
             let mut mt = lock_or_recover(&self.memtable);
             file_format::save(&mut mt, &self.db_path, self.storage_mode)?;
@@ -937,8 +970,12 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
     ///
     /// 锁文件必须保留在固定路径上：删除后其他进程可以创建同名新文件并锁住
     /// 不同的文件实体，从而绕过现有锁。句柄释放后，空的 `.lock` 文件留存是正常现象。
+    ///
+    /// 释放锁后数据库即进入关闭状态（`closed = true`）：后续写操作将被拒绝，
+    /// 防止无锁保护下的多进程双写导致文件撕裂。
     pub fn release_lock(&mut self) {
         self._lock_file.take();
+        self.closed = true;
     }
 
     pub fn node_count(&self) -> usize {

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,10 @@ pub enum TriviumError {
     #[error("数据库已锁定 (Database locked): {0}")]
     DatabaseLocked(String),
 
+    /// 数据库已关闭（close/release_lock 后不可再执行写入，防止无锁双写）
+    #[error("数据库已关闭 (Database closed): 关闭后不能再执行写入操作")]
+    DatabaseClosed,
+
     /// 数据库文件格式损坏或不兼容
     #[error("文件损坏 (Corrupted file): {0}")]
     CorruptedFile(String),

--- a/src/storage/file_format.rs
+++ b/src/storage/file_format.rs
@@ -598,7 +598,23 @@ pub fn load<T: VectorType>(
                     as usize;
             if bq_count > 0 {
                 let sig_size = std::mem::size_of::<BqSignature>();
-                let expected_bq_end = bq_offset + 8 + bq_count * sig_size;
+                // 防整数溢出：bq_count × sig_size 在 64 位下可回绕为小值，
+                // 绕过下方截断校验后触发巨型分配（恶意/损坏文件 DoS）。
+                let Some(sig_bytes) = bq_count.checked_mul(sig_size) else {
+                    return Err(TriviumError::CorruptedFile(format!(
+                        "BQ 块长度溢出 (BQ block size overflow): {} 个签名 × {} 字节",
+                        bq_count, sig_size
+                    )));
+                };
+                let Some(expected_bq_end) = bq_offset
+                    .checked_add(8)
+                    .and_then(|v| v.checked_add(sig_bytes))
+                else {
+                    return Err(TriviumError::CorruptedFile(format!(
+                        "BQ 块偏移溢出 (BQ block offset overflow): offset {} + {} 字节",
+                        bq_offset, sig_bytes
+                    )));
+                };
                 if expected_bq_end > file_len {
                     return Err(TriviumError::CorruptedFile(format!(
                         "BQ 块被截断 (BQ block truncated): 期望 {} 字节 (offset {} + 8 + {} × {})，\
@@ -900,13 +916,24 @@ fn load_bq_block<T: VectorType>(
     }
 
     let sig_size = std::mem::size_of::<BqSignature>();
-    let data_start = bq_offset + 8;
-    let data_end = data_start + bq_count * sig_size;
+    // 防整数溢出：checked 乘法/加法，回绕即视为数据不完整（恶意/损坏文件），
+    // 避免 bq_count 被回绕后绕过 file_len 校验并触发巨型 Vec::with_capacity。
+    let Some(sig_bytes) = bq_count.checked_mul(sig_size) else {
+        tracing::warn!("BQ Block 长度溢出 (BQ Block size overflow): {} 个签名", bq_count);
+        return;
+    };
+    let Some(data_start) = bq_offset.checked_add(8) else {
+        return;
+    };
+    let Some(data_end) = data_start.checked_add(sig_bytes) else {
+        tracing::warn!("BQ Block 偏移溢出 (BQ Block offset overflow)");
+        return;
+    };
 
     if data_end > file_len {
         tracing::warn!(
             "BQ Block 数据不完整 (BQ Block data incomplete)（需要 {} 字节，文件仅剩 {} 字节），跳过恢复",
-            bq_count * sig_size,
+            sig_bytes,
             file_len.saturating_sub(data_start)
         );
         return;


### PR DESCRIPTION
## 修复前：问题描述

- **F1（安全·高）**：`file_format.rs` BQ 块完整性校验中 `bq_count × sig_size` 无保护乘法，64 位下可回绕为小值绕过截断校验，触发巨型 `Vec::with_capacity`（capacity overflow abort）——恶意/损坏 `.tdb` 可致进程崩溃（DoS）
- **F2（语义·中）**：`close()`/`release_lock()` 后 Database 无关闭标记，旧对象仍可写但文件锁已释放 → 多进程双写导致 `.tdb/.vec` 撕裂；Python `__exit__` 只 flush 不 release_lock，与 `close()` 不一致

## 修复后：改动说明（commit 74d719d）

- **F1**：两处 `bq_count×sig_size` 改 `checked_mul/checked_add`，溢出返回 `CorruptedFile`（校验路径）或 warn 跳过（恢复路径）
- **F2**：Database 新增 `closed` 标记（release_lock 置位）；compact/insert/insert_with_id/link/delete/unlink/update_payload/patch_payload/update_vector/flush 入口返回 `DatabaseClosed`；`error.rs` 新增变体；python `__exit__` 对齐

## 验证：修复前后完整输出

### F1（BQ 块溢出）——修复前 vs 修复后

**测试方法**：构造 80 字节畸形 `.tdb`（header v5、bq_offset=61 非 8 对齐、bq_count=2^57），子进程加载绑定并 open。

**修复前输出**：

```
子进程退出码: 3221226505 | 信号: null
子进程错误: thread '<unnamed>' panicked at library\alloc\src\raw_vec\mod.rs:28:5:
capacity overflow
```

→ 进程崩溃（panic），恶意/损坏文件可致 DoS。

**修复后输出**：

```
子进程退出码: 0 | 信号: null
子进程输出: RESULT=ERROR 文件损坏 (Corrupted file): BQ 块长度溢出 (BQ block size overflow): 144115188075855872 个签名 × 384 字节
```

→ 优雅返回 CorruptedFile，进程正常退出。

### F2（close 后写操作）——修复前 vs 修复后

**测试方法**：正常打开 → insert → close() → 继续调用写 API。

**修复前**：close 后 insert/updatePayload/link/delete 静默成功（无报错，但文件锁已释放 → 双写撕裂风险）。

**修复后（PASS=7）**：

```
[PASS] close 后 insert 被拒绝 -> 数据库已关闭 (Database closed): 关闭后不能再执行写入操作
[PASS] close 后 updatePayload 被拒绝 -> 数据库已关闭 (Database closed)
[PASS] close 后 link 被拒绝 -> 数据库已关闭 (Database closed)
[PASS] close 后 delete 被拒绝 -> 数据库已关闭 (Database closed)
[PASS] close 后读操作仍可用 (nodeCount)
[PASS] close 后可同进程重开（B1 不回归）
```

### 测试性质说明

以上黑盒探针是**直接加载本仓库编译产物（napi `.node` 绑定）**&#x8FDB;行的功能测试（脚本见 fork 的 `audit-report/f1-probe.js`、`f2-probe.js`），不是在具体业务项目上跑的。业务侧兼容性另行验证：TriviumDB 已用于真实 RAG 知识库产品（triviumdb-store），升级 0.7.4 后 `triviumdb-store.test.ts` 8/8 通过。

### Rust 回归

engine_deep 25/25、database_advanced 21/21、pipeline_deep 4/4 全绿。
