### PR TITLE
feat(graph): 露出入边查询与可选 expand_labels 白名单

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -241,6 +241,30 @@ const edges = db.getEdges(42)
 edges.forEach(e => console.log(`${e.targetId} (${e.label})`))
 ```
 
+### get_incoming_edges — 获取入边列表
+
+获取指向该节点的所有入边（含 `source_id` / `label` / `weight`）。实现走 Reverse Hash Net：只遍历该节点的入度来源，再读取各源节点出边，**不会全表扫**。`label` 可选，传入则只返回该标签。
+
+**Python：**
+```python
+incoming = db.get_incoming_edges(42)
+about = db.get_incoming_edges(42, label="about")
+for e in about:
+    print(f"{e.source_id} -[:{e.label}]-> 42  w={e.weight}")
+```
+
+**Node.js：**
+```js
+const incoming = db.getIncomingEdges(42)
+const about = db.getIncomingEdges(42, 'about')
+```
+
+**Rust：**
+```rust
+let incoming = db.get_incoming_edges(42, None);
+let about = db.get_incoming_edges(42, Some("about"));
+```
+
 ### contains — 节点存在检查
 
 **Python：**
@@ -299,16 +323,24 @@ db.unlink(1, 2)?;
 
 ### neighbors — N 跳邻居
 
-从指定节点出发，沿有向边进行广度优先遍历（BFS），返回 N 跳以内所有可达节点的 ID。
+从指定节点出发，沿有向边进行广度优先遍历（BFS），返回 N 跳以内所有可达节点的 ID。`labels` 为可选边标签白名单；省略时沿**全部**出边（与历史行为一致）。
 
 **Python：**
 ```python
 neighbor_ids = db.neighbors(id=1, depth=2)  # 2 跳以内的所有邻居
+business = db.neighbors(id=1, depth=1, labels=["about", "decided", "broke", "fixed"])
+```
+
+**Node.js：**
+```js
+db.neighbors(1, 2)
+db.neighbors(1, 1, ['about', 'decided', 'broke', 'fixed'])
 ```
 
 **Rust：**
 ```rust
 let ids = db.neighbors(1, 2);
+let business = db.neighbors_with_labels(1, 1, Some(&["about".into(), "decided".into()]));
 ```
 
 ---
@@ -464,10 +496,13 @@ let results = db.search_advanced(&query_vec, &config)?;
 | `hybrid_alpha` | `f32` | `0.7` | 混合检索中向量权重 (0~1)，(1-alpha) 为稀疏文本权重 |
 | `custom_query_text` | `str`| `None` | (可选) 手动传入用于文本匹配的原始文本 |
 | `force_brute_force` | `bool` | `false`| 强制使用暴力搜索，禁用 QuIVer 图索引（用于基准测试和需要精确结果的场景） |
+| `expand_labels` | `list[str]` / `None` | `None` | 图扩散边标签白名单。`None` 沿全部出边；传入后只沿这些 label 传播，未列出的边（如 `in_workspace`）既不扩散也不占用能量预算 |
 
 > 💡 所有参数均内置安全钳位：`teleport_alpha` 被约束在 [0, 1]，`fista_lambda` 在 [1e-5, 100]，`dpp_quality_weight` 在 [0, 10]。传入越界值不会崩溃，而是被静默钳平。
 
 > 💡 当 `enable_advanced_pipeline = false` 时，`search_advanced` 的行为与 `search` 完全一致。
+
+> 💡 **SA-PPR 与边权（已有行为，本版本未改默认排序）**：扩散按出边 `weight` 的**绝对值**做单层能量归一化，符号决定能量正负（负权抑制）。`label == "inhibition"` 的边强制按负能量传播。`expand_labels` 过滤发生在归一化之前。
 
 ---
 

--- a/src/bindings/nodejs.rs
+++ b/src/bindings/nodejs.rs
@@ -66,12 +66,22 @@ pub mod nodejs {
         pub custom_query_text: Option<String>,
         /// CCSA: 扩散方向偏置向量，让图扩散优先沿语义相近的节点方向传播
         pub diffusion_bias: Option<Vec<f64>>,
+        /// 图扩散边标签白名单；省略时沿全部出边（与历史行为一致）
+        pub expand_labels: Option<Vec<String>>,
     }
 
     /// 节点关系边
     #[napi(object)]
     pub struct JsEdge {
         pub target_id: f64,
+        pub label: String,
+        pub weight: f64,
+    }
+
+    /// 指向当前节点的入边
+    #[napi(object)]
+    pub struct JsIncomingEdge {
+        pub source_id: f64,
         pub label: String,
         pub weight: f64,
     }
@@ -247,6 +257,7 @@ pub mod nodejs {
                 text_boost: None,
                 force_brute_force: None,
                 diffusion_bias: None,
+                expand_labels: None,
             });
 
             let top_k = cfg.top_k.unwrap_or(5);
@@ -275,6 +286,7 @@ pub mod nodejs {
                 diffusion_bias: cfg
                     .diffusion_bias
                     .map(|v| v.iter().map(|&x| x as f32).collect()),
+                expand_labels: cfg.expand_labels.clone(),
                 ..Default::default()
             };
 
@@ -576,11 +588,16 @@ pub mod nodejs {
                 .map_err(|e| napi::Error::from_reason(e.to_string()))
         }
 
-        /// 获取 N 跳邻居节点 ID 列表
+        /// 获取 N 跳邻居节点 ID 列表。`labels` 为边标签白名单，省略则沿全部出边。
         #[napi]
-        pub fn neighbors(&self, id: f64, depth: Option<u32>) -> Vec<f64> {
+        pub fn neighbors(
+            &self,
+            id: f64,
+            depth: Option<u32>,
+            labels: Option<Vec<String>>,
+        ) -> Vec<f64> {
             let depth = depth.unwrap_or(1) as usize;
-            dispatch!(self, db => db.neighbors(id as u64, depth))
+            dispatch!(self, db => db.neighbors_with_labels(id as u64, depth, labels.as_deref()))
                 .into_iter()
                 .map(|id| id as f64)
                 .collect()
@@ -658,6 +675,7 @@ pub mod nodejs {
             top_k: Option<i64>,
             expand_depth: Option<u32>,
             min_score: Option<f64>,
+            expand_labels: Option<Vec<String>>,
         ) -> napi::Result<Vec<JsSearchHit>> {
             let top_k = top_k.unwrap_or(5);
             if top_k <= 0 {
@@ -669,21 +687,30 @@ pub mod nodejs {
             let expand_depth = expand_depth.unwrap_or(0) as usize;
             let min_score = min_score.unwrap_or(0.5) as f32;
 
+            let core_config = crate::database::SearchConfig {
+                top_k,
+                expand_depth,
+                min_score,
+                enable_advanced_pipeline: false,
+                expand_labels,
+                ..Default::default()
+            };
+
             let hits = match &self.inner {
                 DbBackend::F32(db) => {
                     let v: Vec<f32> = query_vector.iter().map(|&x| x as f32).collect();
-                    db.search(&v, top_k, expand_depth, min_score)
+                    db.search_hybrid(None, Some(&v), &core_config)
                 }
                 DbBackend::F16(db) => {
                     let v: Vec<half::f16> = query_vector
                         .iter()
                         .map(|&x| half::f16::from_f64(x))
                         .collect();
-                    db.search(&v, top_k, expand_depth, min_score)
+                    db.search_hybrid(None, Some(&v), &core_config)
                 }
                 DbBackend::U64(db) => {
                     let v: Vec<u64> = query_vector.iter().map(|&x| x as u64).collect();
-                    db.search(&v, top_k, expand_depth, min_score)
+                    db.search_hybrid(None, Some(&v), &core_config)
                 }
             }
             .map_err(|e| napi::Error::from_reason(e.to_string()))?;
@@ -724,6 +751,7 @@ pub mod nodejs {
                 text_boost: None,
                 force_brute_force: None,
                 diffusion_bias: None,
+                expand_labels: None,
             });
 
             let top_k = cfg.top_k.unwrap_or(5);
@@ -752,6 +780,7 @@ pub mod nodejs {
                 diffusion_bias: cfg
                     .diffusion_bias
                     .map(|v| v.iter().map(|&x| x as f32).collect()),
+                expand_labels: cfg.expand_labels.clone(),
                 ..Default::default()
             };
 
@@ -796,6 +825,7 @@ pub mod nodejs {
             expand_depth: Option<u32>,
             min_score: Option<f64>,
             hybrid_alpha: Option<f64>,
+            expand_labels: Option<Vec<String>>,
         ) -> napi::Result<Vec<JsSearchHit>> {
             let top_k = top_k.unwrap_or(5);
             if top_k <= 0 {
@@ -816,6 +846,7 @@ pub mod nodejs {
                 min_score,
                 enable_text_hybrid_search: true,
                 text_boost: boost,
+                expand_labels,
                 ..Default::default()
             };
 
@@ -903,6 +934,20 @@ pub mod nodejs {
                 .into_iter()
                 .map(|e| JsEdge {
                     target_id: e.target_id as f64,
+                    label: e.label,
+                    weight: e.weight as f64,
+                })
+                .collect()
+        }
+
+        /// 获取指向该节点的入边（Reverse Hash Net，O(入度)）。
+        /// `label` 可选，传入则只返回该标签。
+        #[napi]
+        pub fn get_incoming_edges(&self, id: f64, label: Option<String>) -> Vec<JsIncomingEdge> {
+            dispatch!(self, db => db.get_incoming_edges(id as u64, label.as_deref()))
+                .into_iter()
+                .map(|e| JsIncomingEdge {
+                    source_id: e.source_id as f64,
                     label: e.label,
                     weight: e.weight as f64,
                 })

--- a/src/bindings/python.rs
+++ b/src/bindings/python.rs
@@ -57,6 +57,17 @@ pub mod python {
         pub weight: f32,
     }
 
+    #[pyclass(name = "IncomingEdge")]
+    #[derive(Clone)]
+    pub struct PyIncomingEdge {
+        #[pyo3(get)]
+        pub source_id: u64,
+        #[pyo3(get)]
+        pub label: String,
+        #[pyo3(get)]
+        pub weight: f32,
+    }
+
     /// Python 侧的节点完整视图
     #[pyclass(name = "NodeView")]
     pub struct PyNodeView {
@@ -329,7 +340,7 @@ pub mod python {
         /// print(ctx.timings)   # {'hook_pre_search': 0.1, 'graph_expand': 2.3, ...}
         /// print(ctx.custom_data)  # Hook 注入的自定义数据
         /// ```
-        #[pyo3(signature = (query_vector, top_k=5, recall_k=0, rerank_k=0, expand_depth=2, min_score=0.1, payload_filter=None))]
+        #[pyo3(signature = (query_vector, top_k=5, recall_k=0, rerank_k=0, expand_depth=2, min_score=0.1, payload_filter=None, expand_labels=None))]
         fn search_with_context(
             &self,
             py: Python<'_>,
@@ -340,6 +351,7 @@ pub mod python {
             expand_depth: usize,
             min_score: f32,
             payload_filter: Option<&Bound<'_, PyDict>>,
+            expand_labels: Option<Vec<String>>,
         ) -> PyResult<(Vec<PySearchHit>, PyHookContext)> {
             let rust_filter = match payload_filter {
                 Some(dict) => Some(dict_to_filter(py, dict)?),
@@ -352,6 +364,7 @@ pub mod python {
                 expand_depth,
                 min_score,
                 payload_filter: rust_filter,
+                expand_labels,
                 ..Default::default()
             };
 
@@ -479,7 +492,7 @@ pub mod python {
             )
         }
 
-        #[pyo3(signature = (query_vector, top_k=5, recall_k=0, rerank_k=0, expand_depth=0, min_score=0.5, payload_filter=None))]
+        #[pyo3(signature = (query_vector, top_k=5, recall_k=0, rerank_k=0, expand_depth=0, min_score=0.5, payload_filter=None, expand_labels=None))]
         fn search(
             &self,
             py: Python<'_>,
@@ -490,6 +503,7 @@ pub mod python {
             expand_depth: usize,
             min_score: f32,
             payload_filter: Option<&Bound<'_, PyDict>>,
+            expand_labels: Option<Vec<String>>,
         ) -> PyResult<Vec<PySearchHit>> {
             let rust_filter = match payload_filter {
                 Some(dict) => Some(dict_to_filter(py, dict)?),
@@ -504,6 +518,7 @@ pub mod python {
                 min_score,
                 enable_advanced_pipeline: false,
                 payload_filter: rust_filter,
+                expand_labels,
                 ..Default::default()
             };
 
@@ -555,7 +570,8 @@ pub mod python {
             text_boost=1.5,
             custom_query_text=None,
             payload_filter=None,
-            force_brute_force=false
+            force_brute_force=false,
+            expand_labels=None
         ))]
         fn search_advanced(
             &self,
@@ -579,6 +595,7 @@ pub mod python {
             custom_query_text: Option<String>,
             payload_filter: Option<&Bound<'_, PyDict>>,
             force_brute_force: bool,
+            expand_labels: Option<Vec<String>>,
         ) -> PyResult<Vec<PySearchHit>> {
             // 解析 payload_filter（类 MongoDB 语法的 dict -> Rust Filter）
             let rust_filter = match payload_filter {
@@ -604,6 +621,7 @@ pub mod python {
                 text_boost,
                 force_brute_force,
                 payload_filter: rust_filter,
+                expand_labels,
                 ..Default::default()
             };
 
@@ -638,7 +656,7 @@ pub mod python {
                 .collect())
         }
 
-        #[pyo3(signature = (query_vector, query_text, top_k=5, expand_depth=2, min_score=0.1, hybrid_alpha=0.7, payload_filter=None))]
+        #[pyo3(signature = (query_vector, query_text, top_k=5, expand_depth=2, min_score=0.1, hybrid_alpha=0.7, payload_filter=None, expand_labels=None))]
         fn search_hybrid(
             &self,
             py: Python<'_>,
@@ -649,6 +667,7 @@ pub mod python {
             min_score: f32,
             hybrid_alpha: f32,
             payload_filter: Option<&Bound<'_, PyDict>>,
+            expand_labels: Option<Vec<String>>,
         ) -> PyResult<Vec<PySearchHit>> {
             let rust_filter = match payload_filter {
                 Some(dict) => Some(dict_to_filter(py, dict)?),
@@ -665,6 +684,7 @@ pub mod python {
                 enable_text_hybrid_search: true,
                 text_boost: boost,
                 payload_filter: rust_filter,
+                expand_labels,
                 ..Default::default()
             };
             let results = match &self.inner {
@@ -831,6 +851,19 @@ pub mod python {
                 .collect()
         }
 
+        /// 获取指向该节点的入边（Reverse Hash Net）。label 可选过滤。
+        #[pyo3(signature = (id, label=None))]
+        fn get_incoming_edges(&self, id: u64, label: Option<&str>) -> Vec<PyIncomingEdge> {
+            dispatch!(self, db => db.get_incoming_edges(id, label))
+                .into_iter()
+                .map(|e| PyIncomingEdge {
+                    source_id: e.source_id,
+                    label: e.label,
+                    weight: e.weight,
+                })
+                .collect()
+        }
+
         fn get(&self, py: Python<'_>, id: u64) -> PyResult<Option<PyNodeView>> {
             match &self.inner {
                 DbBackend::F32(db) => {
@@ -895,9 +928,9 @@ pub mod python {
             Ok(None)
         }
 
-        #[pyo3(signature = (id, depth=1))]
-        fn neighbors(&self, id: u64, depth: usize) -> Vec<u64> {
-            dispatch!(self, db => db.neighbors(id, depth))
+        #[pyo3(signature = (id, depth=1, labels=None))]
+        fn neighbors(&self, id: u64, depth: usize, labels: Option<Vec<String>>) -> Vec<u64> {
+            dispatch!(self, db => db.neighbors_with_labels(id, depth, labels.as_deref()))
         }
 
         fn node_count(&self) -> usize {

--- a/src/database/config.rs
+++ b/src/database/config.rs
@@ -102,6 +102,13 @@ pub struct SearchConfig {
     /// - RAG 应用：传入查询向量本身，让扩散偏向查询语义方向
     /// - 推荐系统：传入用户偏好向量，让扩散偏向用户兴趣方向
     pub diffusion_bias: Option<Vec<f32>>,
+
+    /// 图扩散 / SA-PPR 边标签白名单。
+    ///
+    /// `None`（默认）沿全部出边扩散，与历史行为一致。
+    /// `Some(labels)` 时只沿这些 label 传播能量；未列出的边（如 `in_workspace`）
+    /// 既不成为邻居，也不占用归一化能量预算。
+    pub expand_labels: Option<Vec<String>>,
 }
 
 impl Default for SearchConfig {
@@ -129,6 +136,7 @@ impl Default for SearchConfig {
             bm25_b: 0.75,
             payload_filter: None,
             diffusion_bias: None,
+            expand_labels: None,
         }
     }
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -609,6 +609,17 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
         mt.get_edges(id).map(|e| e.to_vec()).unwrap_or_default()
     }
 
+    /// 获取指向 `id` 的入边（Reverse Hash Net，O(in_degree)）。
+    /// `label` 为 Some 时只返回该标签。
+    pub fn get_incoming_edges(
+        &self,
+        id: NodeId,
+        label: Option<&str>,
+    ) -> Vec<crate::node::IncomingEdge> {
+        let mt = lock_or_recover(&self.memtable);
+        mt.get_incoming_edges(id, label)
+    }
+
     pub fn get_all_ids(&self) -> Vec<NodeId> {
         let mt = lock_or_recover(&self.memtable);
         mt.get_all_ids()
@@ -704,6 +715,16 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
     }
 
     pub fn neighbors(&self, id: NodeId, depth: usize) -> Vec<NodeId> {
+        self.neighbors_with_labels(id, depth, None)
+    }
+
+    /// N 跳 BFS。`labels` 为 Some 时只沿白名单标签扩散；None 保持原行为（全 label）。
+    pub fn neighbors_with_labels(
+        &self,
+        id: NodeId,
+        depth: usize,
+        labels: Option<&[String]>,
+    ) -> Vec<NodeId> {
         use std::collections::{HashSet, VecDeque};
         let mt = lock_or_recover(&self.memtable);
         let mut visited = HashSet::new();
@@ -716,6 +737,11 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
             }
             if let Some(edges) = mt.get_edges(curr) {
                 for edge in edges {
+                    if let Some(whitelist) = labels
+                        && !whitelist.iter().any(|l| l == &edge.label)
+                    {
+                        continue;
+                    }
                     if visited.insert(edge.target_id) {
                         queue.push_back((edge.target_id, d + 1));
                     }

--- a/src/database/pipeline.rs
+++ b/src/database/pipeline.rs
@@ -249,7 +249,7 @@ pub(crate) fn execute_pipeline<T: VectorType>(
     //  L6 + L7: SA-PPR 有限深度图谱扩散 + 不应期/侧向抑制
     // ═══════════════════════════════════════════════════════
     let t_graph = std::time::Instant::now();
-    let mut expanded = crate::graph::traversal::expand_graph(
+    let mut expanded = crate::graph::traversal::expand_graph_with_labels(
         &mt,
         seeds,
         config.expand_depth,
@@ -258,6 +258,7 @@ pub(crate) fn execute_pipeline<T: VectorType>(
         config.lateral_inhibition_threshold,
         config.enable_refractory_fatigue,
         config.diffusion_bias.as_deref(), // CCSA: 传递扩散偏置向量
+        config.expand_labels.as_deref(),
     );
     ctx.record_timing("graph_expand", t_graph.elapsed());
 

--- a/src/graph/traversal.rs
+++ b/src/graph/traversal.rs
@@ -19,6 +19,39 @@ pub fn expand_graph<T: crate::VectorType>(
     enable_refractory_fatigue: bool,
     diffusion_bias: Option<&[f32]>,
 ) -> Vec<SearchHit> {
+    expand_graph_with_labels(
+        db,
+        seeds,
+        max_depth,
+        restart_alpha,
+        enable_inverse_inhibition,
+        lateral_inhibition_threshold,
+        enable_refractory_fatigue,
+        diffusion_bias,
+        None,
+    )
+}
+
+/// 与 [`expand_graph`] 相同，但可限制只沿 `expand_labels` 白名单扩散。
+///
+/// `expand_labels = None` 时行为与历史 `expand_graph` 完全一致。
+/// 白名单过滤发生在能量归一化之前：未列出的边既不传播、也不占用预算。
+///
+/// 边权语义（本函数不改变默认排序，仅如实使用已有规则）：
+/// - 有效边权取 `weight` 的绝对值参与单层能量归一化；
+/// - `weight` 的符号决定能量正负（负权抑制）；
+/// - `label == "inhibition"` 强制按负能量传播，与 `weight` 符号无关。
+pub fn expand_graph_with_labels<T: crate::VectorType>(
+    db: &MemTable<T>,
+    seeds: Vec<SearchHit>,
+    max_depth: usize,
+    restart_alpha: f32,
+    enable_inverse_inhibition: bool,
+    lateral_inhibition_threshold: usize,
+    enable_refractory_fatigue: bool,
+    diffusion_bias: Option<&[f32]>,
+    expand_labels: Option<&[String]>,
+) -> Vec<SearchHit> {
     if max_depth == 0 || seeds.is_empty() {
         return seeds;
     }
@@ -88,6 +121,11 @@ pub fn expand_graph<T: crate::VectorType>(
             let mut weighted_edges = Vec::with_capacity(edges.len());
             let mut normalizer = 0.0f32;
             for edge in edges {
+                if let Some(whitelist) = expand_labels
+                    && !whitelist.iter().any(|l| l == &edge.label)
+                {
+                    continue;
+                }
                 if !edge.weight.is_finite() || edge.weight == 0.0 {
                     continue;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use database::Database;
 pub use error::{Result, TriviumError};
 pub use filter::Filter;
 pub use hook::{CompositeHook, FfiHook, HookContext, NoopHook, SearchHook};
-pub use node::{Edge, NodeId, NodeView, SearchHit};
+pub use node::{Edge, IncomingEdge, NodeId, NodeView, SearchHit};
 pub mod vector;
 pub use vector::VectorType;
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -12,6 +12,17 @@ pub struct Edge {
     pub weight: Weight,
 }
 
+/// 入边视图：指向当前节点的有向带权边。
+///
+/// 存储层只维护 `incoming_edges: dst → [src]`（Reverse Hash Net），
+/// label / weight 从源节点出边表解析，避免另建一份边存储。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IncomingEdge {
+    pub source_id: NodeId,
+    pub label: Label,
+    pub weight: Weight,
+}
+
 /// 用户在查询时返回的统一节点数据视图
 #[derive(Debug, Clone)]
 pub struct NodeView<T> {

--- a/src/storage/memtable.rs
+++ b/src/storage/memtable.rs
@@ -3,7 +3,7 @@ use crate::error::{Result, TriviumError};
 use crate::index::bq::BqSignature;
 use crate::index::quiver::{QuIVer, QuIVerConfig};
 use crate::index::text::TextIndex;
-use crate::node::{Edge, NodeId};
+use crate::node::{Edge, IncomingEdge, NodeId};
 use crate::storage::vec_pool::VecPool;
 use std::collections::{HashMap, HashSet};
 use std::sync::OnceLock;
@@ -869,6 +869,39 @@ impl<T: VectorType> MemTable<T> {
             .get(&id)
             .map(|v| v.as_slice())
             .unwrap_or(&[])
+    }
+
+    /// 获取指向 id 的入边（含 label / weight）。
+    ///
+    /// 利用 Reverse Hash Net 只遍历入度来源，再读取各源节点出边；
+    /// `label` 为 Some 时只返回该标签。多标签平行边会分别返回。
+    pub fn get_incoming_edges(&self, id: NodeId, label: Option<&str>) -> Vec<IncomingEdge> {
+        let mut seen_src = HashSet::new();
+        let mut result = Vec::new();
+        for &src in self.get_incoming_sources(id) {
+            if !seen_src.insert(src) {
+                continue;
+            }
+            let Some(edges) = self.get_edges(src) else {
+                continue;
+            };
+            for edge in edges {
+                if edge.target_id != id {
+                    continue;
+                }
+                if let Some(want) = label
+                    && edge.label != want
+                {
+                    continue;
+                }
+                result.push(IncomingEdge {
+                    source_id: src,
+                    label: edge.label.clone(),
+                    weight: edge.weight,
+                });
+            }
+        }
+        result
     }
 
     /// 按标签查询所有边 (src, dst) 对，O(1) 查找

--- a/tests/agent_memory_graph.rs
+++ b/tests/agent_memory_graph.rs
@@ -1,0 +1,180 @@
+//! Agent 记忆图语义：业务边 vs in_workspace 粘合边
+//!
+//! 下游 dsh-trivium 把记忆记成「节点 + 有向带权边」。
+//! 业务边是 about / decided / broke / fixed；每条记忆还连一条
+//! in_workspace 到工作区根。若 expand / neighbors 沿全部边扩散，
+//! 工作区根会把整库粘成一团。
+
+use triviumdb::database::SearchConfig;
+use triviumdb::Database;
+
+const DIM: usize = 4;
+
+fn tmp_db(name: &str) -> String {
+    let dir = std::env::temp_dir().join("triviumdb_test");
+    std::fs::create_dir_all(&dir).ok();
+    let path = dir
+        .join(format!("agent_mem_{}", name))
+        .to_string_lossy()
+        .to_string();
+    cleanup(&path);
+    path
+}
+
+fn cleanup(path: &str) {
+    for ext in &["", ".wal", ".vec", ".lock", ".flush_ok"] {
+        let _ = std::fs::remove_file(format!("{}{}", path, ext));
+    }
+}
+
+const BUSINESS: &[&str] = &["about", "decided", "broke", "fixed"];
+
+fn business_labels() -> Vec<String> {
+    BUSINESS.iter().map(|s| (*s).to_string()).collect()
+}
+
+/// preference -[:about]-> entity
+/// preference -[:in_workspace]-> workspace
+/// decision  -[:decided]-> entity
+/// decision  -[:in_workspace]-> workspace
+fn build_memory_graph(path: &str) -> (Database<f32>, u64, u64, u64, u64) {
+    let mut db = Database::<f32>::open(path, DIM).unwrap();
+    db.disable_auto_compaction();
+
+    let workspace = db
+        .insert(
+            &[0.0, 0.0, 0.0, 1.0],
+            serde_json::json!({"kind": "workspace"}),
+        )
+        .unwrap();
+    let entity = db
+        .insert(
+            &[0.0, 1.0, 0.0, 0.0],
+            serde_json::json!({"kind": "entity", "name": "auth"}),
+        )
+        .unwrap();
+    let preference = db
+        .insert(
+            &[1.0, 0.0, 0.0, 0.0],
+            serde_json::json!({"kind": "preference", "text": "prefer jwt"}),
+        )
+        .unwrap();
+    let decision = db
+        .insert(
+            &[0.9, 0.1, 0.0, 0.0],
+            serde_json::json!({"kind": "decision", "text": "use jwt"}),
+        )
+        .unwrap();
+
+    db.link(preference, entity, "about", 1.0).unwrap();
+    db.link(preference, workspace, "in_workspace", 1.0).unwrap();
+    db.link(decision, entity, "decided", 1.0).unwrap();
+    db.link(decision, workspace, "in_workspace", 1.0).unwrap();
+
+    (db, workspace, entity, preference, decision)
+}
+
+#[test]
+fn 入边能从entity找到about过来的preference() {
+    let path = tmp_db("incoming");
+    let (db, workspace, entity, preference, decision) = build_memory_graph(&path);
+
+    let about = db.get_incoming_edges(entity, Some("about"));
+    assert_eq!(about.len(), 1);
+    assert_eq!(about[0].source_id, preference);
+    assert_eq!(about[0].label, "about");
+
+    let decided = db.get_incoming_edges(entity, Some("decided"));
+    assert_eq!(decided.len(), 1);
+    assert_eq!(decided[0].source_id, decision);
+
+    let all_in = db.get_incoming_edges(entity, None);
+    assert_eq!(all_in.len(), 2);
+
+    let ws_in = db.get_incoming_edges(workspace, None);
+    assert_eq!(ws_in.len(), 2);
+    assert!(ws_in.iter().all(|e| e.label == "in_workspace"));
+
+    drop(db);
+    cleanup(&path);
+}
+
+#[test]
+fn 业务边扩1跳不含workspace根() {
+    let path = tmp_db("expand_hop");
+    let (db, workspace, entity, preference, decision) = build_memory_graph(&path);
+    let labels = business_labels();
+
+    let unfiltered = db.neighbors(preference, 1);
+    assert!(unfiltered.contains(&entity));
+    assert!(
+        unfiltered.contains(&workspace),
+        "不传 labels 必须保持历史行为：in_workspace 仍会扩到工作区根"
+    );
+
+    let filtered = db.neighbors_with_labels(preference, 1, Some(&labels));
+    assert!(filtered.contains(&entity), "about 应扩到 entity");
+    assert!(
+        !filtered.contains(&workspace),
+        "业务白名单不应顺着 in_workspace 扩到工作区根"
+    );
+    assert!(!filtered.contains(&decision));
+
+    let from_decision = db.neighbors_with_labels(decision, 1, Some(&labels));
+    assert!(from_decision.contains(&entity));
+    assert!(!from_decision.contains(&workspace));
+
+    drop(db);
+    cleanup(&path);
+}
+
+#[test]
+fn search_expand_labels_不把workspace粘进结果() {
+    let path = tmp_db("search_expand");
+    let (db, workspace, entity, preference, _decision) = build_memory_graph(&path);
+    let labels = business_labels();
+    let query = [1.0, 0.0, 0.0, 0.0];
+
+    let glued = db
+        .search_advanced(
+            &query,
+            &SearchConfig {
+                top_k: 10,
+                expand_depth: 1,
+                min_score: 0.1,
+                enable_advanced_pipeline: false,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    let glued_ids: Vec<u64> = glued.iter().map(|h| h.id).collect();
+    assert!(glued_ids.contains(&preference));
+    assert!(
+        glued_ids.contains(&workspace),
+        "不传 expand_labels 时 depth=1 仍会扩到 workspace"
+    );
+
+    let scoped = db
+        .search_advanced(
+            &query,
+            &SearchConfig {
+                top_k: 10,
+                expand_depth: 1,
+                min_score: 0.1,
+                enable_advanced_pipeline: false,
+                expand_labels: Some(labels),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    let scoped_ids: Vec<u64> = scoped.iter().map(|h| h.id).collect();
+    assert!(scoped_ids.contains(&preference));
+    assert!(scoped_ids.contains(&entity), "about 应把 entity 扩进结果");
+    assert!(
+        !scoped_ids.contains(&workspace),
+        "expand_labels 白名单不应把 workspace 粘进结果"
+    );
+
+    drop(db);
+    cleanup(&path);
+}

--- a/tests/unit/database.rs
+++ b/tests/unit/database.rs
@@ -392,6 +392,44 @@ fn neighbors_基础() {
 }
 
 #[test]
+fn neighbors_with_labels_过滤非业务边() {
+    let mut db = open_db("neighbors_labels");
+    let mem = db.insert(&[1.0, 0.0, 0.0], json!({"kind": "memory"})).unwrap();
+    let entity = db.insert(&[0.0, 1.0, 0.0], json!({"kind": "entity"})).unwrap();
+    let ws = db.insert(&[0.0, 0.0, 1.0], json!({"kind": "workspace"})).unwrap();
+    db.link(mem, entity, "about", 1.0).unwrap();
+    db.link(mem, ws, "in_workspace", 1.0).unwrap();
+
+    let all = db.neighbors(mem, 1);
+    assert!(all.contains(&entity));
+    assert!(all.contains(&ws), "不传 labels 应仍沿全部出边");
+
+    let business = db.neighbors_with_labels(mem, 1, Some(&["about".into()]));
+    assert!(business.contains(&entity));
+    assert!(!business.contains(&ws), "白名单不应顺着 in_workspace 扩散");
+}
+
+#[test]
+fn get_incoming_edges_从entity找到about过来的preference() {
+    let mut db = open_db("incoming_about");
+    let pref = db.insert(&[1.0, 0.0, 0.0], json!({"kind": "preference"})).unwrap();
+    let entity = db.insert(&[0.0, 1.0, 0.0], json!({"kind": "entity"})).unwrap();
+    let ws = db.insert(&[0.0, 0.0, 1.0], json!({"kind": "workspace"})).unwrap();
+    db.link(pref, entity, "about", 1.0).unwrap();
+    db.link(pref, ws, "in_workspace", 1.0).unwrap();
+
+    let incoming = db.get_incoming_edges(entity, Some("about"));
+    assert_eq!(incoming.len(), 1);
+    assert_eq!(incoming[0].source_id, pref);
+    assert_eq!(incoming[0].label, "about");
+
+    let ws_in = db.get_incoming_edges(ws, None);
+    assert_eq!(ws_in.len(), 1);
+    assert_eq!(ws_in[0].source_id, pref);
+    assert_eq!(ws_in[0].label, "in_workspace");
+}
+
+#[test]
 fn dim_和_all_node_ids() {
     let mut db = open_db("dim_ids");
     assert_eq!(db.dim(), 3);

--- a/tests/unit/memtable.rs
+++ b/tests/unit/memtable.rs
@@ -267,6 +267,30 @@ fn get_in_degree_和_incoming_sources() {
 }
 
 #[test]
+fn get_incoming_edges_含label和weight() {
+    let mut mt = make_mt();
+    for i in 1..=3 {
+        mt.insert_with_id(i, &[i as f32, 0.0, 0.0], json!({}))
+            .unwrap();
+    }
+    mt.link(1, 3, "about".into(), 0.9).unwrap();
+    mt.link(1, 3, "in_workspace".into(), 1.0).unwrap();
+    mt.link(2, 3, "decided".into(), 0.5).unwrap();
+
+    let all = mt.get_incoming_edges(3, None);
+    assert_eq!(all.len(), 3);
+
+    let about = mt.get_incoming_edges(3, Some("about"));
+    assert_eq!(about.len(), 1);
+    assert_eq!(about[0].source_id, 1);
+    assert_eq!(about[0].label, "about");
+    assert!((about[0].weight - 0.9).abs() < 1e-6);
+
+    let none = mt.get_incoming_edges(3, Some("missing"));
+    assert!(none.is_empty());
+}
+
+#[test]
 fn get_edges_by_label() {
     let mut mt = make_mt();
     for i in 1..=3 {

--- a/tests/unit/traversal.rs
+++ b/tests/unit/traversal.rs
@@ -210,3 +210,25 @@ fn expand_空seeds() {
     let result = expand_graph(&mt, vec![], 2, 0.0, false, 0, false, None);
     assert!(result.is_empty());
 }
+
+#[test]
+fn expand_labels_白名单不沿其他边扩散() {
+    let mt = build_graph();
+    let seeds = vec![seed(1, 1.0)];
+    let labels = ["knows".to_string()];
+    let result = triviumdb::graph::traversal::expand_graph_with_labels(
+        &mt,
+        seeds,
+        1,
+        0.0,
+        false,
+        0,
+        false,
+        None,
+        Some(&labels),
+    );
+    let ids: Vec<u64> = result.iter().map(|h| h.id).collect();
+    assert!(ids.contains(&1));
+    assert!(ids.contains(&2), "应沿 knows 扩到节点 2");
+    assert!(!ids.contains(&4), "不应沿 works 扩到节点 4");
+}

--- a/triviumdb.d.ts
+++ b/triviumdb.d.ts
@@ -31,6 +31,15 @@ export interface JsEdge {
   weight: number;
 }
 
+export interface JsIncomingEdge {
+  /** 源节点 ID */
+  sourceId: number;
+  /** 边的分组类型或者名称 */
+  label: string;
+  /** 边权重 */
+  weight: number;
+}
+
 export interface JsNodeView<T = any> {
   /** 节点 ID */
   id: number;
@@ -127,6 +136,11 @@ export interface JsSearchConfig {
    * - 推荐系统: 传入用户偏好向量，让扩散偏向用户兴趣方向
    */
   diffusionBias?: number[];
+  /**
+   * 图扩散边标签白名单。省略时沿全部出边（与历史行为一致）。
+   * 传入如 `['about','decided','broke','fixed']` 时不会顺着 `in_workspace` 扩散。
+   */
+  expandLabels?: string[];
 }
 
 export interface JsClusterResult {
@@ -331,9 +345,10 @@ export class TriviumDB {
    * 图谱上的 N 跳搜索 (广度优先遍历)
    * @param id    起始点
    * @param depth 跳数 (默认 1)
+   * @param labels 边标签白名单；省略则沿全部出边
    * @returns 深度之内的所有不重复的周边点 ID
    */
-  neighbors(id: number, depth?: number): number[];
+  neighbors(id: number, depth?: number, labels?: string[]): number[];
 
   /**
    * 获取节点的出边列表
@@ -341,6 +356,13 @@ export class TriviumDB {
    * @returns 该节点出发的所有有向边
    */
   getEdges(id: number): JsEdge[];
+
+  /**
+   * 获取指向该节点的入边（Reverse Hash Net，O(入度)）
+   * @param id 节点 ID
+   * @param label 可选标签过滤
+   */
+  getIncomingEdges(id: number, label?: string): JsIncomingEdge[];
 
   // ── 检索与查询 ──
 
@@ -350,8 +372,9 @@ export class TriviumDB {
    * @param topK        向外找多少个最相似锚点向量 (默认 5)
    * @param expandDepth 获取到上述锚点后，在图谱里扩散的跳跃深度 (默认 0，纯粹退化为向量相似度检索)
    * @param minScore    只接受相似度大于这个阈值的搜索命中 (默认 0.5)
+   * @param expandLabels 图扩散边标签白名单；省略则沿全部出边
    */
-  search(queryVector: Vector, topK?: number, expandDepth?: number, minScore?: number): JsSearchHit[];
+  search(queryVector: Vector, topK?: number, expandDepth?: number, minScore?: number, expandLabels?: string[]): JsSearchHit[];
 
   /**
    * 认知管线检索：向量锚定 + FISTA 残差寻隐 + PPR 图扩散 + DPP 多样性采样
@@ -368,8 +391,9 @@ export class TriviumDB {
    * @param expandDepth 扩散深度
    * @param minScore    最小分数
    * @param hybridAlpha 混合权重 (0.0~1.0)，越大向量占比越高。默认 0.7
+   * @param expandLabels 图扩散边标签白名单；省略则沿全部出边
    */
-  searchHybrid(queryVector: Vector, queryText: string, topK?: number, expandDepth?: number, minScore?: number, hybridAlpha?: number): JsSearchHit[];
+  searchHybrid(queryVector: Vector, queryText: string, topK?: number, expandDepth?: number, minScore?: number, hybridAlpha?: number, expandLabels?: string[]): JsSearchHit[];
 
   /**
    * 建立用于双路召回的长文本 BM25 索引


### PR DESCRIPTION
## 动机（Agent 记忆图，请 review 设计，不是要求合并）

下游进程内插件（单文件 `.tdb`）按「节点 + 有向带权边」记记忆。业务边是 `about` / `decided` / `broke` / `fixed`；每条记忆还连一条 `in_workspace` 到工作区根。

若 `search` / `neighbors` 沿全部边扩散，工作区根会把整库粘成一团。节点少时插件层可以自己扫出入边；节点到千～万时，全表扫入边会钝。希望把图语义收回引擎。

## API（向后兼容：不传新参数 = 旧行为）

- `getIncomingEdges(id, label?)` / `get_incoming_edges(id, label=None)` / Rust `get_incoming_edges(id, Option<&str>)`
  - 走已有 Reverse Hash Net（`incoming_edges: dst → [src]`），从源节点出边解析 label/weight
  - **不重写存储**
- `neighbors(id, depth?, labels?: string[])`
  - Rust 保留 `neighbors(id, depth)`，新增 `neighbors_with_labels`
  - 位置参数风格与现有 `neighbors(id, depth)` 对齐，避免把第二参改成 options 对象
- `SearchConfig.expandLabels` / `expand_labels`
  - `search` / `searchHybrid` / `searchAdvanced` / `searchWithContext` 透传
  - `None` 沿全部出边；`Some(labels)` 在 SA-PPR **能量归一化之前**丢掉非白名单边（`in_workspace` 既不到达、也不占预算）

Node napi 与 Python PyO3 对称。

## 边权（已有行为，本 PR 未改默认排序）

SA-PPR 本来就按出边 `weight` 的绝对值做单层能量归一化，符号决定正负能量；`label == "inhibition"` 强制负能量。本 PR 只在 `docs/api-reference.md` 写清，没有偷偷改排序。

## 测试

- 业务边扩 1 跳不含 workspace 根；不传 `labels` 仍会扩到根
- 入边能从 entity 找到 `about` 过来的 preference
- `search_advanced` + `expand_labels` 不会把 workspace 粘进结果

    cargo test --test agent_memory_graph --test unit -- get_incoming_edges neighbors_with_labels expand_labels

## 刻意没做（请作者表态）

入边和 `expandLabels` 绑在同一个 PR：两边都要改绑定 / `SearchConfig` / `d.ts`，拆开几乎是同一批文件的两次冲突。下面两项会碰 WAL 格式或过滤语义，没有硬造补丁。

### 1) `unlink(src, dst, label?)`

省略 `label` 保持「删两点间全部边」；传入则只删该 label。

阻塞点：`WalEntry::Unlink { src, dst }` 是 bincode 枚举，给现有变体加字段会破坏旧 WAL 回放。较稳的最小改法是：

- 保留 `Unlink { src, dst }` = 全删（旧日志可回放）
- 新增 `UnlinkLabel { src, dst, label }` = 只删该 label
- MemTable 按 label 维护 `incoming_edges` / `in_degrees` / `label_index`

建议测试：同一对节点同时有 `about` 和 `in_workspace`；`unlink(..., "about")` 只断 about。

草案：https://github.com/QWQcool/TriviumDB/issues/2

### 2) `FIND { untilAt: { $lt: ISO } }`

现状：`Filter::$lt` 只接受数字（`as_f64()`），ISO 字符串会报 `$lt 需要数字`。`createIndex` 是等值倒排，帮不了范围扫描。

最小补齐（不上新时间类型）：operand 为 string 时按字符串比；为 number 时仍按数字。ISO-8601 字典序可用。过期决策也可以继续在插件层用 `payload.untilAt` 过滤。

草案：https://github.com/QWQcool/TriviumDB/issues/1

---

如果方向不对，我们会按你的意见改 API 再拆/收。感谢 review。