### PR TITLE
fix: release write lock when TriviumDB context manager exits (#20)

### DIFF
--- a/src/bindings/python.rs
+++ b/src/bindings/python.rs
@@ -1439,8 +1439,12 @@ pub mod python {
             _exc_val: Option<&Bound<'_, PyAny>>,
             _exc_tb: Option<&Bound<'_, PyAny>>,
         ) -> PyResult<bool> {
-            self.flush()?;
-            Ok(false)
+            // 上下文管理器退出时关闭数据库并释放单写锁，
+            // 若块内已显式 close()（数据库已关闭）则视为无操作。
+            match dispatch!(self, mut db => db.close()) {
+                Ok(()) | Err(crate::error::TriviumError::DatabaseClosed) => Ok(false),
+                Err(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
+            }
         }
 
         fn batch_insert(


### PR DESCRIPTION
## 问题

Fixes #20


## 修复

`__exit__` 改为走 `Database::close()`（落盘 + 释放锁）：

```rust
fn __exit__(...) -> PyResult<bool> {
    match dispatch!(self, mut db => db.close()) {
        Ok(()) | Err(crate::error::TriviumError::DatabaseClosed) => Ok(false),
        Err(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
    }
}
```

只读模式下 `close()` 跳过 flush 但仍释放锁，同样正确。块内异常照常向上传播。

## 行为变更（预期，符合惯例）

`with` 块退出后 `db` 即为已关闭状态，块外再用会抛 `DatabaseClosed`。

