### PR TITLE
fix: 空 WAL 版本不兼容时放行，避免旧库升级后无法打开

### DIFF
--- a/src/storage/wal.rs
+++ b/src/storage/wal.rs
@@ -249,10 +249,18 @@ impl Wal {
             }
             let version = u16::from_le_bytes([prefix[4], prefix[5]]);
             if version != WAL_VERSION {
-                return Err(TriviumError::UnsupportedWalVersion {
-                    found: version,
-                    supported: WAL_VERSION,
-                });
+                // 空 WAL（只有头部、没有任何待回放记录）不存在条目格式差异，
+                // 版本不兼容不会影响数据完整性 —— 按空 WAL 处理，
+                // 让下一次写入以新版本头重建，避免旧库升级后彻底打不开。
+                // 只要 WAL 里还有哪怕一条记录，就仍然严格拒绝，
+                // 防止用新格式去回放旧格式条目造成数据损坏。
+                if file.metadata()?.len() != WAL_HEADER_SIZE {
+                    return Err(TriviumError::UnsupportedWalVersion {
+                        found: version,
+                        supported: WAL_VERSION,
+                    });
+                }
+                return Ok((Vec::new(), WAL_HEADER_SIZE));
             }
             let (entries, offset) = Self::read_entries_from_reader(BufReader::new(file))?;
             return Ok((entries, offset + WAL_HEADER_SIZE));

--- a/tests/unit/wal.rs
+++ b/tests/unit/wal.rs
@@ -261,9 +261,14 @@ fn wal_needs_recovery_非空文件() {
 fn wal明确拒绝不支持的版本() {
     let path = tmp_db("unsupported_version");
     cleanup(&path);
+    // 头部（版本 0x7FFF）+ 一段条目负载，确保这是一个「非空」WAL：
+    // 非空意味着存在待回放数据，任何版本不兼容都必须拒绝，不能放行。
+    // 空 WAL 的向后兼容处理见 wal_空WAL_版本不兼容_应放行。
     std::fs::write(
         format!("{}.wal", path),
-        [b'T', b'V', b'W', b'L', 0xFF, 0x7F],
+        [
+            b'T', b'V', b'W', b'L', 0xFF, 0x7F, 0x10, 0x00, 0x00, 0x00, 0xAA, 0xBB, 0xCC, 0xDD,
+        ],
     )
     .unwrap();
 
@@ -333,4 +338,50 @@ fn wal_len过大_合理性检查() {
 
     let (entries, _) = Wal::read_entries_from_reader::<f32>(Cursor::new(&buf)).unwrap();
     assert!(entries.is_empty(), "超大 len 应触发安全停止");
+}
+
+// ════════════════════════════════════════════════════════════════
+//  WAL 版本向后兼容
+// ════════════════════════════════════════════════════════════════
+
+/// 构造一个指定版本的 WAL 文件（可选附加伪造条目），写到 `<path>.wal`
+fn write_wal_with_version(path: &str, version: u16, extra: &[u8]) {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"TVWL");
+    bytes.extend_from_slice(&version.to_le_bytes());
+    bytes.extend_from_slice(extra);
+    std::fs::write(format!("{}.wal", path), &bytes).unwrap();
+}
+
+/// 空 WAL（只有头部、零条目）版本不兼容时应放行 —— 没有待回放数据，
+/// 放行不会有数据完整性风险，却能让旧版本创建的库正常升级。
+#[test]
+fn wal_空WAL_版本不兼容_应放行() {
+    let path = tmp_db("legacy_empty_wal");
+    cleanup(&path);
+    write_wal_with_version(&path, 2, &[]);
+
+    let (entries, offset) = Wal::read_entries::<f32>(&path).unwrap();
+    assert!(entries.is_empty(), "空 WAL 应解析出 0 条记录");
+    assert_eq!(offset, 6, "空 WAL 应只消费头部 6 字节");
+
+    cleanup(&path);
+}
+
+/// WAL 里还有条目时，版本不兼容必须继续拒绝 —— 不能用新格式回放旧格式条目。
+#[test]
+fn wal_非空WAL_版本不兼容_应拒绝() {
+    let path = tmp_db("legacy_nonempty_wal");
+    cleanup(&path);
+    // 伪造 32 字节条目负载，使 WAL 长度超过头部
+    write_wal_with_version(&path, 2, &[0xAA; 32]);
+
+    let err = Wal::read_entries::<f32>(&path).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("WAL 版本") || msg.contains("WAL version"),
+        "应当报 WAL 版本不兼容，实际错误：{msg}"
+    );
+
+    cleanup(&path);
 }


### PR DESCRIPTION
v0.8.2 把 WAL_VERSION 从 2 升到 3（src/storage/wal.rs:9）， 导致 v0.8.1 及更早版本创建的数据库在升级后全部无法打开：

    TDB_ERROR: 不支持的 WAL 版本: 发现 2，当前支持 3

更棘手的是这构成一个死锁：唯一的迁移入口 migrate_to() 要求
先成功 open，而 open 阶段就会因 WAL 版本检查失败，
用户无法在不回退旧版本的前提下导出数据。

实测（Windows / npm 包 0.8.1 建库 -> 0.8.2 打开）：
  - 0.8.1 建库 + flush + close  -> 打不开
  - 0.8.1 建库 + 不 flush       -> 打不开
  - migrate_to()                -> 无法调用（open 已失败）

本改动只在「WAL 只有头部、零条目」时放行：
此时没有待回放数据，版本不兼容不影响数据完整性，
下次写入会以新版本头重建 WAL。
只要 WAL 中还有任意一条记录，仍严格拒绝，
避免用新格式回放旧格式条目造成损坏。

测试：
  - 新增 wal_空WAL_版本不兼容_应放行
  - 新增 wal_非空WAL_版本不兼容_应拒绝
  - 调整 wal明确拒绝不支持的版本：原用例构造的正好是 6 字节空 WAL， 改为非空 WAL，使其继续守住「拒绝不兼容版本」的原意图

端到端验证：0.8.1 建的 50 节点库，修复后 nodeCount=50、
payload 校验 50/50 通过；未修复版本仍然报错。