### PR TITLE
fix: 修复 TQL 行数上限的四个核心缺陷 (#32)

### DIFF
--- a/docs/tql-reference.md
+++ b/docs/tql-reference.md
@@ -307,8 +307,43 @@ RETURN b
 | 机制 | 配置 | 说明 |
 |------|------|------|
 | 预算熔断 | 100,000 步 | 单次查询最多评估 10 万步，防止内存爆炸 |
-| 行数上限 | LIMIT 或默认 5,000 | 结果行数达标后立即停止所有 DFS 分支 |
+| 显式 LIMIT | 用户指定 | `LIMIT` 始终优先，不会被默认上限夹低；上限为 100,000 步预算 |
+| 默认行数上限 | 按风险区分 | 见下表；结果行数达标后立即停止所有 DFS 分支 |
 | 环路检测 | 可变长路径 | `HashSet<u64>` 跟踪已访问节点 |
+
+**默认行数上限**（仅在查询**未**显式写 `LIMIT` 时生效）：
+
+| 查询形态 | 默认上限 | 理由 |
+|---|---|---|
+| `MATCH (n)`（无边模式）、`FIND`、`SEARCH` | 无上限 | 每个节点最多产出一行，行数天然被节点数界定，不会爆炸 |
+| `MATCH (a)-[..]->(b)`（含边模式） | 5,000 | 多跳路径可能笛卡尔积爆炸，需要兜底 |
+
+**触及上限时默认报错**，不静默返回子集。语义对齐 ClickHouse 的
+`result_overflow_mode`（默认 `throw`）与 Elasticsearch 超 `max_result_window` 的行为。
+
+| 配置项 | 默认 | 说明 |
+|---|---|---|
+| `max_query_rows` | 未设置 | 未设置 = 按上表风险区分；`0` = 完全不限；`n` = 一律不超过 n 行。显式 `LIMIT` 优先级高于本配置 |
+| `row_overflow` | `"throw"` | `"throw"` = 触及上限即返回错误；`"break"` = 截断并记录 `tracing::warn!` 告警后返回部分结果 |
+| `memory_limit` | `0`（不限） | 结果集内存预算，会反推出一条行数上限，与 `max_query_rows` 取更严格者。**内存是硬约束，显式 `LIMIT` 也无法突破** |
+
+```python
+# 全量枚举大图：解除默认上限
+db = triviumdb.TriviumDB("graph.db", dim=768, max_query_rows=0)
+
+# 保留旧的「优雅截断」行为（v0.8.x 及更早的默认）
+db = triviumdb.TriviumDB("graph.db", dim=768, row_overflow="break")
+```
+
+聚合类查询（`count` / `sum` / `DISTINCT` / `ORDER BY`）一旦触及上限，返回的是
+**错误答案**而非部分答案，错误信息会明确区分这两种后果。`row_overflow="break"`
+下这类查询只会告警，需自行判断可接受性。
+
+`SET` / `DELETE` 的 `MATCH` 匹配集不受行数上限约束，避免静默的部分写入。
+
+内存护栅是**预算反推**而非实时计量，有两处已知低估：多变量模式
+（`MATCH (a)-[..]->(b)`）每行含多个节点但按 1 个估算；投影裁剪的节省未计入
+（它在物化之后才跑，峰值已经产生）。作为防 OOM 的护栅足够，不应当作精确计量。
 
 ---
 
@@ -511,9 +546,28 @@ ORDER BY _.heat DESC        -- FIND/SEARCH 场景
 ```sql
 LIMIT 10              -- 最多返回 10 条
 LIMIT 10 OFFSET 20    -- 跳过前 20 条，返回 10 条
+LIMIT 20000           -- 显式 LIMIT 不会被默认上限夹低
+OFFSET 5000           -- 可翻页到任意位置，不受默认上限影响
 ```
 
 **执行顺序**：`WHERE 过滤 → RANK（如有）→ 聚合/DISTINCT → ORDER BY → OFFSET → LIMIT`
+
+**分页保证**：全表扫描按节点 ID 升序返回，顺序在同一数据集上稳定且跨进程可重现，
+因此按 `LIMIT n OFFSET k*n` 逐页取全集不会漏行也不会重复。
+
+```python
+# 分页导出全图
+page, offset = 1000, 0
+while True:
+    rows = db.tql(f"MATCH (n) RETURN n LIMIT {page} OFFSET {offset}")
+    if not rows:
+        break
+    handle(rows)
+    offset += page
+```
+
+**聚合与排序拿到的是完整输入**：`RETURN count(n)` 统计的是全部匹配行，
+`ORDER BY ... LIMIT 10` 取的是全局 top-10，不是「前若干行里的 top-10」。
 
 ---
 

--- a/python/triviumdb/__init__.pyi
+++ b/python/triviumdb/__init__.pyi
@@ -13,6 +13,7 @@ DType = Literal["f32", "f16", "u64"]
 SyncMode = Literal["full", "normal", "off"]
 AccessMode = Literal["read_write", "read_only", "immutable"]
 MissingIndexPolicy = Literal["fallback", "build_in_memory", "error"]
+RowOverflowPolicy = Literal["throw", "break"]
 EdgeDirection = Literal["out", "in", "both"]
 ReachabilityDirection = Literal["outgoing", "incoming", "both"]
 
@@ -139,7 +140,7 @@ class Transaction:
 @final
 class TriviumDB:
     dtype: str
-    def __new__(cls, path: str, dim: int = 1536, dtype: DType = 'f32', sync_mode: SyncMode = 'normal', load_text_index: bool = False, auto_build_quiver: bool = True, expected_nodes: int | None = None, memory_limit_mb: int = 0, access_mode: AccessMode = 'read_write', missing_index_policy: MissingIndexPolicy = 'fallback') -> "TriviumDB": ...
+    def __new__(cls, path: str, dim: int = 1536, dtype: DType = 'f32', sync_mode: SyncMode = 'normal', load_text_index: bool = False, auto_build_quiver: bool = True, expected_nodes: int | None = None, memory_limit_mb: int = 0, access_mode: AccessMode = 'read_write', missing_index_policy: MissingIndexPolicy = 'fallback', max_query_rows: int | None = None, row_overflow: RowOverflowPolicy = 'throw') -> "TriviumDB": ...
     def all_node_ids(self) -> list[int]: ...
     def batch_insert(self, vectors: Sequence[Vector], payloads: Sequence[Any]) -> list[int]: ...
     def batch_insert_with_ids(self, ids: Sequence[int], vectors: Sequence[Vector], payloads: Sequence[Any]) -> None: ...

--- a/scripts/generate_pyi.py
+++ b/scripts/generate_pyi.py
@@ -77,11 +77,12 @@ for _t, _names in {
     "int": "id src dst key depth expand_depth min_depth max_depth max_visited_nodes "
            "max_anchor_nodes parallelism additional mb interval_secs min_community_size "
            "max_iterations dim new_dim memory_limit_mb expected_nodes top_k recall_k rerank_k "
-           "max_edges_per_node max_edges max_results seed",
+           "max_edges_per_node max_edges max_results seed max_query_rows",
     "float": "weight min_score teleport_alpha fista_lambda fista_threshold "
              "dpp_quality_weight text_boost hybrid_alpha min_edge_weight resolution",
     "str": "text keyword field query query_text mode lib_path path new_path generation_id "
-           "dtype sync_mode access_mode missing_index_policy direction label custom_query_text",
+           "dtype sync_mode access_mode missing_index_policy direction label custom_query_text "
+           "row_overflow",
     "bool": "load_text_index auto_build_quiver enabled compute_centroids "
             "enable_advanced_pipeline enable_sparse_residual enable_dpp "
             "enable_refractory_fatigue enable_text_hybrid_search force_brute_force",
@@ -93,6 +94,7 @@ QUALIFIED_PARAM_TYPES = {
     "TriviumDB.__new__.sync_mode": "SyncMode",
     "TriviumDB.__new__.access_mode": "AccessMode",
     "TriviumDB.__new__.missing_index_policy": "MissingIndexPolicy",
+    "TriviumDB.__new__.row_overflow": "RowOverflowPolicy",
     "TriviumDB.set_sync_mode.mode": "SyncMode",
     "TriviumDB.search.edge_direction": "EdgeDirection",
     "TriviumDB.search_grouped.edge_direction": "EdgeDirection",
@@ -169,6 +171,7 @@ DType = Literal["f32", "f16", "u64"]
 SyncMode = Literal["full", "normal", "off"]
 AccessMode = Literal["read_write", "read_only", "immutable"]
 MissingIndexPolicy = Literal["fallback", "build_in_memory", "error"]
+RowOverflowPolicy = Literal["throw", "break"]
 EdgeDirection = Literal["out", "in", "both"]
 ReachabilityDirection = Literal["outgoing", "incoming", "both"]
 '''

--- a/src/bindings/nodejs.rs
+++ b/src/bindings/nodejs.rs
@@ -297,6 +297,8 @@ pub mod nodejs {
         pub memory_limit_mb: Option<f64>,
         pub access_mode: Option<String>,
         pub missing_index_policy: Option<String>,
+        pub max_query_rows: Option<f64>,
+        pub row_overflow: Option<String>,
     }
 
     /// 高级管线专用配置结构
@@ -599,6 +601,16 @@ pub mod nodejs {
         }
     }
 
+    fn parse_row_overflow(value: Option<&str>) -> napi::Result<crate::database::RowOverflowPolicy> {
+        match value.unwrap_or("throw") {
+            "throw" => Ok(crate::database::RowOverflowPolicy::Throw),
+            "break" => Ok(crate::database::RowOverflowPolicy::Break),
+            _ => Err(napi::Error::from_reason(
+                "rowOverflow 必须是 throw / break",
+            )),
+        }
+    }
+
     fn parse_sync_mode(s: &str) -> napi::Result<crate::storage::wal::SyncMode> {
         crate::storage::wal::SyncMode::parse(s).map_err(napi::Error::from_reason)
     }
@@ -666,6 +678,8 @@ pub mod nodejs {
                     memory_limit_mb: None,
                     access_mode: None,
                     missing_index_policy: None,
+                    max_query_rows: None,
+                    row_overflow: None,
                 },
             };
             let dim = options.dim.unwrap_or(1536) as usize;
@@ -682,6 +696,10 @@ pub mod nodejs {
             let memory_limit = memory_limit_mb
                 .checked_mul(1024 * 1024)
                 .ok_or_else(|| napi::Error::from_reason("memoryLimitMb 换算字节时溢出"))?;
+            let max_query_rows = options
+                .max_query_rows
+                .map(|value| parse_safe_usize(value, "maxQueryRows"))
+                .transpose()?;
             let config = crate::database::Config {
                 dim,
                 sync_mode: parse_sync_mode(options.sync_mode.as_deref().unwrap_or("normal"))?,
@@ -694,6 +712,8 @@ pub mod nodejs {
                 missing_index_policy: parse_missing_index_policy(
                     options.missing_index_policy.as_deref(),
                 )?,
+                max_query_rows,
+                row_overflow: parse_row_overflow(options.row_overflow.as_deref())?,
             };
             let dtype_str = dtype.as_str();
 

--- a/src/bindings/python.rs
+++ b/src/bindings/python.rs
@@ -440,6 +440,16 @@ pub mod python {
         }
     }
 
+    fn parse_row_overflow(value: &str) -> PyResult<crate::database::RowOverflowPolicy> {
+        match value {
+            "throw" => Ok(crate::database::RowOverflowPolicy::Throw),
+            "break" => Ok(crate::database::RowOverflowPolicy::Break),
+            _ => Err(pyo3::exceptions::PyValueError::new_err(
+                "row_overflow 必须是 throw / break",
+            )),
+        }
+    }
+
     fn parse_edge_direction(value: &str) -> PyResult<crate::database::EdgeDirection> {
         match value {
             "out" | "outgoing" => Ok(crate::database::EdgeDirection::Outgoing),
@@ -454,7 +464,7 @@ pub mod python {
     #[pymethods]
     impl PyTriviumDB {
         #[new]
-        #[pyo3(signature = (path, dim=1536, dtype="f32", sync_mode="normal", load_text_index=false, auto_build_quiver=true, expected_nodes=None, memory_limit_mb=0, access_mode="read_write", missing_index_policy="fallback"))]
+        #[pyo3(signature = (path, dim=1536, dtype="f32", sync_mode="normal", load_text_index=false, auto_build_quiver=true, expected_nodes=None, memory_limit_mb=0, access_mode="read_write", missing_index_policy="fallback", max_query_rows=None, row_overflow="throw"))]
         fn new(
             path: &str,
             dim: usize,
@@ -466,6 +476,8 @@ pub mod python {
             memory_limit_mb: usize,
             access_mode: &str,
             missing_index_policy: &str,
+            max_query_rows: Option<usize>,
+            row_overflow: &str,
         ) -> PyResult<Self> {
             let sm = parse_sync_mode(sync_mode)?;
             let memory_limit = memory_limit_mb.checked_mul(1024 * 1024).ok_or_else(|| {
@@ -480,6 +492,8 @@ pub mod python {
                 memory_limit,
                 access_mode: parse_access_mode(access_mode)?,
                 missing_index_policy: parse_missing_index_policy(missing_index_policy)?,
+                max_query_rows,
+                row_overflow: parse_row_overflow(row_overflow)?,
                 ..Default::default()
             };
             let inner = match dtype {

--- a/src/database/config.rs
+++ b/src/database/config.rs
@@ -41,6 +41,25 @@ pub enum EdgeDirection {
     Both,
 }
 
+/// 结果行数触及上限时的行为。语义对齐 ClickHouse 的 `result_overflow_mode`。
+///
+/// 只在上限**不是**用户显式 `LIMIT` 时生效——用户自己写的 `LIMIT` 达成即为预期结果。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RowOverflowPolicy {
+    /// 返回错误（默认）。宁可失败，也不把子集伪装成全集。
+    ///
+    /// 与 ClickHouse `result_overflow_mode=throw`、Elasticsearch 超
+    /// `max_result_window` 的行为一致。
+    #[default]
+    Throw,
+    /// 截断并记录 `tracing::warn!` 告警后返回部分结果。
+    ///
+    /// 对应 ClickHouse `result_overflow_mode=break`。注意：聚合类查询
+    /// （`count`/`sum`/`DISTINCT`/`ORDER BY`）一旦触及上限，返回的是**错误答案**
+    /// 而非部分答案，此策略下只会告警，需自行判断可接受性。
+    Break,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct Config {
     pub dim: usize,
@@ -56,6 +75,18 @@ pub struct Config {
     pub memory_limit: usize,
     pub access_mode: AccessMode,
     pub missing_index_policy: MissingIndexPolicy,
+    /// TQL 单次查询的默认行数上限（仅在查询未显式写 LIMIT 时生效）。
+    ///
+    /// - `None`（默认）：按风险区分。无边模式（`MATCH (n)`、`FIND`、`SEARCH`）行数天然被
+    ///   节点数界定，不设默认上限；含边模式可能笛卡尔积爆炸，保留 5,000 默认上限。
+    /// - `Some(0)`：完全不设默认上限。
+    /// - `Some(n)`：无边/含边一律不超过 n 行。
+    ///
+    /// 任何情况下仍受 100,000 步预算熔断约束。显式 `LIMIT` 始终优先于本配置。
+    pub max_query_rows: Option<usize>,
+    /// 结果因行数上限（而非用户显式 `LIMIT`）被截断时的行为，默认
+    /// [`RowOverflowPolicy::Throw`]（报错）。
+    pub row_overflow: RowOverflowPolicy,
 }
 
 impl Default for Config {
@@ -70,6 +101,8 @@ impl Default for Config {
             memory_limit: 0,
             access_mode: AccessMode::ReadWrite,
             missing_index_policy: MissingIndexPolicy::Fallback,
+            max_query_rows: None,
+            row_overflow: RowOverflowPolicy::Throw,
         }
     }
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -13,8 +13,8 @@ pub mod transaction;
 
 // 从子模块重导出公开类型，保持对外 API 不变
 pub use config::{
-    AccessMode, BatchSearchConfig, Config, EdgeDirection, MissingIndexPolicy, SearchConfig,
-    StorageMode,
+    AccessMode, BatchSearchConfig, Config, EdgeDirection, MissingIndexPolicy, RowOverflowPolicy,
+    SearchConfig, StorageMode,
 };
 pub use facade::{DatabaseReader, DatabaseWriter};
 pub use transaction::{Transaction, TxBuilder};
@@ -234,6 +234,10 @@ pub struct Database<T: VectorType> {
     _lock_file: Option<std::fs::File>,
     /// 内存上限（字节），0 = 无限制
     memory_limit: usize,
+    /// TQL 默认行数上限；None = 按风险区分，Some(0) = 不限
+    max_query_rows: Option<usize>,
+    /// 触及非用户指定的行数上限时的行为
+    row_overflow: crate::database::config::RowOverflowPolicy,
     /// 存储模式
     pub(crate) storage_mode: StorageMode,
     /// 检索管线 Hook（默认 NoopHook，零开销）
@@ -556,6 +560,8 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
             compaction: None,
             _lock_file: lock_file,
             memory_limit: config.memory_limit,
+            max_query_rows: config.max_query_rows,
+            row_overflow: config.row_overflow,
             storage_mode: config.storage_mode,
             hook: Arc::new(NoopHook),
             stateful_search: Arc::new(Mutex::new(())),
@@ -753,6 +759,29 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
     /// 设为 0 表示无限制（默认）。
     pub fn set_memory_limit(&mut self, bytes: usize) {
         self.memory_limit = bytes;
+    }
+
+    /// 设置 TQL 单次查询的默认行数上限（仅在查询未显式写 `LIMIT` 时生效）。
+    ///
+    /// `None` = 按风险区分（无边模式不限、含边模式 5,000）；`Some(0)` = 不设默认上限；
+    /// `Some(n)` = 一律不超过 n 行。结果集内存预算（`memory_limit`）同样会反推出
+    /// 一个上限，两者取更严格者。
+    pub fn set_max_query_rows(&mut self, rows: Option<usize>) {
+        self.max_query_rows = rows;
+    }
+
+    /// 设置触及非用户指定的行数上限时的行为（默认 `Throw`，即报错）。
+    pub fn set_row_overflow(&mut self, policy: crate::database::config::RowOverflowPolicy) {
+        self.row_overflow = policy;
+    }
+
+    /// 当前的 TQL 行数与内存配额。
+    fn tql_limits(&self) -> crate::query::tql_executor::TqlLimits {
+        crate::query::tql_executor::TqlLimits {
+            max_query_rows: self.max_query_rows,
+            row_overflow: self.row_overflow,
+            memory_limit: self.memory_limit,
+        }
     }
 
     /// 为后续插入主动预留额外节点容量。
@@ -1861,7 +1890,7 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
         let _operation = self.enter_operation()?;
         let query = crate::query::tql_parser::parse_tql(input).map_err(TriviumError::QueryParse)?;
         let mt = read_or_recover(&self.memtable);
-        crate::query::tql_executor::execute_tql(&query, &mt)
+        crate::query::tql_executor::execute_tql_with_limits(&query, &mt, self.tql_limits())
     }
 
     /// 执行 TQL，并返回可同时承载节点与标量列的一等值结果。
@@ -1869,7 +1898,7 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
         let _operation = self.enter_operation()?;
         let query = crate::query::tql_parser::parse_tql(input).map_err(TriviumError::QueryParse)?;
         let mt = read_or_recover(&self.memtable);
-        crate::query::tql_executor::execute_tql_values(&query, &mt)
+        crate::query::tql_executor::execute_tql_values_with_limits(&query, &mt, self.tql_limits())
     }
 
     /// 解析并准备可重复绑定执行的只读 TQL。
@@ -1888,7 +1917,7 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
         let _operation = self.enter_operation()?;
         let query = prepared.bind(parameters)?;
         let mt = read_or_recover(&self.memtable);
-        crate::query::tql_executor::execute_tql_values(&query, &mt)
+        crate::query::tql_executor::execute_tql_values_with_limits(&query, &mt, self.tql_limits())
     }
 
     /// TQL 写操作入口
@@ -2143,8 +2172,8 @@ impl<T: VectorType + serde::Serialize + serde::de::DeserializeOwned> Database<T>
         T: serde::Serialize + serde::de::DeserializeOwned,
     {
         let mt = read_or_recover(&self.memtable);
-        let mut node_ids = mt.all_node_ids();
-        node_ids.sort();
+        // all_node_ids() 已保证升序
+        let node_ids = mt.all_node_ids();
 
         let mut new_db = Database::<T>::open(new_path, new_dim)?;
 

--- a/src/query/planner.rs
+++ b/src/query/planner.rs
@@ -446,6 +446,12 @@ fn bitmap_filter_candidates<T: VectorType>(
     Some((fields, candidates))
 }
 
+/// 集合差：`left - right`。
+///
+/// **契约：`left` 与 `right` 都必须按升序排列。** 这是双指针归并，`right_index`
+/// 只前进不回退；若 `left` 无序，游标会越过本该排除的元素，导致 `$ne`/`$nin`
+/// 错误地返回应被排除的行。调用方传入的 universe 依赖
+/// `MemTable::all_node_ids()` 的升序保证。
 fn difference_sorted(left: &[NodeId], right: &[NodeId]) -> Vec<NodeId> {
     let mut output = Vec::with_capacity(left.len());
     let (mut left_index, mut right_index) = (0usize, 0usize);

--- a/src/query/tql_executor.rs
+++ b/src/query/tql_executor.rs
@@ -13,6 +13,7 @@ use super::planner::{
 };
 use super::tql_ast::*;
 use crate::VectorType;
+use crate::database::config::RowOverflowPolicy;
 use crate::error::TriviumError;
 use crate::filter::Filter;
 use crate::node::{Node, NodeId};
@@ -78,14 +79,71 @@ pub enum MutationOp<T: VectorType> {
 const MAX_BUDGET: usize = 100_000;
 const DEFAULT_ROW_LIMIT: usize = 5_000;
 
+/// TQL 执行期的行数与内存配额。
+///
+/// 与 [`crate::database::Config`] 的 `max_query_rows` / `row_overflow` /
+/// `memory_limit` 一一对应；默认值等价于「按风险区分 + 超限报错」。
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TqlLimits {
+    /// 未显式写 `LIMIT` 时的默认行数上限。`None` = 按风险区分，`Some(0)` = 不限。
+    pub max_query_rows: Option<usize>,
+    /// 触及非用户指定的行数上限时的行为。
+    pub row_overflow: RowOverflowPolicy,
+    /// 结果集内存预算（字节），0 = 不限。
+    pub memory_limit: usize,
+}
+
+impl TqlLimits {
+    /// 不设行数上限、不设内存预算。
+    ///
+    /// DML 的 MATCH 取值必须用这个：若匹配集被上限截断，`SET`/`DELETE`
+    /// 就只会改到一个子集，造成静默的部分写入。
+    const UNLIMITED: Self = Self {
+        max_query_rows: Some(0),
+        row_overflow: RowOverflowPolicy::Break,
+        memory_limit: 0,
+    };
+}
+
+/// 由内存预算反推结果集行数上限；`0` 预算表示不限。
+///
+/// 每行成本由 [`build_node`] 的向量拷贝主导——它对每个节点做 `vector.to_vec()`，
+/// dim=1536 的 f32 即 6 KiB/节点。这是**预算反推**而非实时计量，有两处已知低估：
+/// 多变量模式（`MATCH (a)-[..]->(b)`）每行含多个节点，此处按 1 个估算；
+/// `apply_projection_pruning` 的节省也未计入（它在物化之后才跑，峰值已经产生）。
+/// 作为防 OOM 的护栅足够，不应被当成精确计量。
+fn memory_derived_row_cap<T: VectorType>(memory_limit: usize, mt: &MemTable<T>) -> usize {
+    if memory_limit == 0 {
+        return usize::MAX;
+    }
+    /// payload + HashMap key + Node 字段的粗估开销
+    const PER_ROW_OVERHEAD: usize = 256;
+    let per_row = mt
+        .dim()
+        .saturating_mul(std::mem::size_of::<T>())
+        .saturating_add(PER_ROW_OVERHEAD)
+        .max(1);
+    // 至少放行 1 行：预算再小也不该让查询直接返回空集
+    (memory_limit / per_row).max(1)
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 //  公开入口
 // ═══════════════════════════════════════════════════════════════════════
 
-/// 执行一个已解析的 TqlQuery
+/// 执行一个已解析的 TqlQuery（使用默认行数配额）
 pub fn execute_tql<T: VectorType>(
     query: &TqlQuery,
     memtable: &MemTable<T>,
+) -> Result<TqlResult<T>, TriviumError> {
+    execute_tql_with_limits(query, memtable, TqlLimits::default())
+}
+
+/// 执行一个已解析的 TqlQuery，并指定行数配额。
+pub fn execute_tql_with_limits<T: VectorType>(
+    query: &TqlQuery,
+    memtable: &MemTable<T>,
+    limits: TqlLimits,
 ) -> Result<TqlResult<T>, TriviumError> {
     if query.explain {
         if query.analyze {
@@ -93,7 +151,7 @@ pub fn execute_tql<T: VectorType>(
             let mut executable = query.clone();
             executable.explain = false;
             executable.analyze = false;
-            let rows = execute_tql(&executable, memtable)?;
+            let rows = execute_tql_with_limits(&executable, memtable, limits)?;
             return Ok(generate_explain_plan(
                 query,
                 memtable,
@@ -103,9 +161,33 @@ pub fn execute_tql<T: VectorType>(
         return Ok(generate_explain_plan(query, memtable, None));
     }
     if !query.pipeline.is_empty() {
-        return execute_pipeline_node_query(query, memtable);
+        return execute_pipeline_node_query(query, memtable, limits);
     }
 
+    // 无边模式（MATCH (n) / FIND / SEARCH）每个节点最多产出一行，行数天然被节点数界定，
+    // 不可能笛卡尔积爆炸；含边模式才需要默认上限兜底。
+    let is_bounded_entry = match &query.entry {
+        QueryEntry::Match { pattern } | QueryEntry::OptionalMatch { pattern } => {
+            pattern.edges.is_empty()
+        }
+        QueryEntry::Find { .. } | QueryEntry::Search { .. } => true,
+    };
+
+    // 解析默认上限：显式配置优先，否则按风险区分。usize::MAX 表示「不设默认上限」。
+    let configured_cap = match limits.max_query_rows {
+        Some(0) => usize::MAX,
+        Some(n) => n,
+        None if is_bounded_entry => usize::MAX,
+        None => DEFAULT_ROW_LIMIT,
+    };
+
+    // 内存护栅：由预算反推行数上限，与配置上限取更严格者，复用同一套截断/告知机制。
+    // 对齐 Neo4j 的 db.memory.transaction.max_size 与 ClickHouse 的 max_result_bytes。
+    let memory_cap = memory_derived_row_cap(limits.memory_limit, memtable);
+    let default_cap = configured_cap.min(memory_cap);
+    let capped_by_memory = memory_cap < configured_cap;
+
+    let offset = query.offset.unwrap_or(0);
     let ordered_find = matches!(
         &query.entry,
         QueryEntry::Find { filter } if find_ordered_find_plan(query, filter, memtable).is_some()
@@ -113,29 +195,53 @@ pub fn execute_tql<T: VectorType>(
     let requires_full_input = query.rank.is_some()
         || (!query.order_by.is_empty() && !ordered_find)
         || matches!(&query.returns, ReturnClause::Expressions(exprs) if exprs.iter().any(|expr| is_aggregate(&expr.kind) || expr.distinct));
-    let row_limit = if requires_full_input {
-        DEFAULT_ROW_LIMIT
+
+    // 聚合 / 排序 / RANK 必须拿到完整输入：用用户的 LIMIT 去截断*输入*会算出错误答案
+    // （例如 count(n) 只数了前 N 行），所以这里只受默认上限约束。
+    // 注意 offset 在这三种形态下也是后置的（先聚合/排序，再 OFFSET），所以同样要
+    // 叠加进预算，否则 `ORDER BY .. OFFSET 4000` 会把预算耗在被跳过的行上。
+    let (row_limit, limit_is_user_supplied) = if requires_full_input {
+        (default_cap.saturating_add(offset), false)
     } else {
-        query
-            .limit
-            .and_then(|limit| limit.checked_add(query.offset.unwrap_or(0)))
-            .unwrap_or(DEFAULT_ROW_LIMIT)
-            .min(DEFAULT_ROW_LIMIT)
+        match query.limit {
+            // 显式 LIMIT：优先级高于 max_query_rows 配置（允许用户为个别查询突破默认值），
+            // 但内存是硬约束——触及 memory_cap 时必须报错，否则护栅形同虚设。
+            Some(limit) => {
+                let requested = limit.saturating_add(offset);
+                if requested > memory_cap.saturating_add(offset) {
+                    return Err(TriviumError::QueryExecution(format!(
+                        "显式 LIMIT {} (+ OFFSET {}) 请求 {} 行会超过内存预算派生的上限 {} 行",
+                        limit, offset, requested, memory_cap
+                    )));
+                }
+                (requested, true)
+            }
+            // 无 LIMIT：默认上限作用于「返回行数」，故同样把 offset 叠加上去，
+            // 否则 `OFFSET 5000` 会把整个预算消耗在被跳过的行上而返回 0 行。
+            None => (default_cap.saturating_add(offset), false),
+        }
     };
 
-    let execution_row_limit = if query.rank.is_some() {
-        MAX_BUDGET.saturating_add(1)
+    // 步数预算只约束「边展开」的工作量——那才是笛卡尔积爆炸的来源。
+    // 无边模式的成本随候选数线性增长（每候选恰好 1 步、最多 1 行），拿步数去拦它
+    // 等于给全表扫描设了个 10 万节点的隐形天花板，与行数上限的语义自相矛盾。
+    let step_budget = if is_bounded_entry {
+        usize::MAX
     } else {
-        row_limit
+        MAX_BUDGET
     };
+
+    // 多取一行作为探针：若扫描真的还有第 row_limit+1 行，就能确证「被截断」，
+    // 而不是靠 `len() == cap` 去猜（那会把恰好产出 cap 行的查询误报成截断）。
+    let scan_limit = row_limit.saturating_add(1);
     let (mut results, ordered_output) = match &query.entry {
-        QueryEntry::Find { filter } => execute_find(filter, query, memtable, execution_row_limit)?,
+        QueryEntry::Find { filter } => execute_find(filter, query, memtable, scan_limit)?,
         QueryEntry::Match { pattern } => (
-            execute_match(pattern, query, memtable, execution_row_limit, false)?,
+            execute_match(pattern, query, memtable, scan_limit, step_budget, false)?,
             false,
         ),
         QueryEntry::OptionalMatch { pattern } => (
-            execute_match(pattern, query, memtable, execution_row_limit, true)?,
+            execute_match(pattern, query, memtable, scan_limit, step_budget, true)?,
             false,
         ),
         QueryEntry::Search {
@@ -143,17 +249,18 @@ pub fn execute_tql<T: VectorType>(
             top_k,
             expand,
         } => (
-            execute_search(
-                vector,
-                *top_k,
-                expand.as_ref(),
-                query,
-                memtable,
-                execution_row_limit,
-            )?,
+            execute_search(vector, *top_k, expand.as_ref(), query, memtable, scan_limit)?,
             false,
         ),
     };
+
+    // 截断检测必须在这里取样：一旦经过聚合/OFFSET/LIMIT，行数就被重塑了
+    // （聚合会把 N 行塌缩成 1 行 count，届时永远检测不到截断）。
+    // 探针行存在 ⇒ 确证被截断；随后立刻丢弃，否则会污染 count 等聚合结果。
+    let truncated = results.len() > row_limit;
+    if truncated {
+        results.truncate(row_limit);
+    }
 
     if let Some(rank) = &query.rank {
         results = apply_graph_first_rank(results, rank, memtable)?;
@@ -186,12 +293,77 @@ pub fn execute_tql<T: VectorType>(
     // 投影裁剪：对仅属性引用的变量，剥离 vector + edges 节省内存
     apply_projection_pruning(&query.returns, &mut results);
 
+    // 用户自己写的 LIMIT 达成即为预期，不算「静默丢数据」；其余任何截断都必须告知。
+    if truncated && !limit_is_user_supplied {
+        report_row_limit_truncation(RowLimitTruncation {
+            row_limit,
+            by_memory: capped_by_memory,
+            corrupts_result: requires_full_input,
+            policy: limits.row_overflow,
+        })?;
+    }
+
     Ok(results)
+}
+
+/// 一次「非用户指定的行数上限」截断事件。
+struct RowLimitTruncation {
+    /// 实际生效的行数上限
+    row_limit: usize,
+    /// 上限来自内存预算而非 `max_query_rows`
+    by_memory: bool,
+    /// 该查询形态下截断会让结果**错误**而非仅仅不完整
+    /// （聚合 / DISTINCT / ORDER BY / RANK 都需要完整输入）
+    corrupts_result: bool,
+    policy: RowOverflowPolicy,
+}
+
+/// 结果被非用户指定的行数上限截断时的告知路径。
+///
+/// `Throw` 返回错误，`Break` 记录告警。文案区分「不完整」与「错误」两种后果：
+/// 前者是少了行，后者是 `count`/`ORDER BY` 之类算出了错的答案。
+fn report_row_limit_truncation(event: RowLimitTruncation) -> Result<(), TriviumError> {
+    let RowLimitTruncation {
+        row_limit,
+        by_memory,
+        corrupts_result,
+        policy,
+    } = event;
+
+    let cause = if by_memory {
+        "内存预算 (memory budget)"
+    } else {
+        "行数上限 max_query_rows (row limit)"
+    };
+    let consequence = if corrupts_result {
+        "聚合/排序需要完整输入，结果是错误的而非仅不完整 \
+         (aggregation/ordering needs full input: the result is WRONG, not merely partial)"
+    } else {
+        "返回的只是子集 (the returned rows are only a subset)"
+    };
+    let remedy = if by_memory {
+        "请用 LIMIT/OFFSET 分页，或调高 memory_limit \
+         (paginate with LIMIT/OFFSET, or raise memory_limit)"
+    } else {
+        "请用 LIMIT/OFFSET 分页，或调整 max_query_rows \
+         (paginate with LIMIT/OFFSET, or adjust max_query_rows)"
+    };
+    let message =
+        format!("TQL 结果在 {row_limit} 行处被{cause}截断：{consequence}。{remedy}");
+
+    match policy {
+        RowOverflowPolicy::Throw => Err(TriviumError::QueryExecution(message)),
+        RowOverflowPolicy::Break => {
+            tracing::warn!("{}", message);
+            Ok(())
+        }
+    }
 }
 
 fn execute_pipeline_set<T: VectorType>(
     query: &TqlQuery,
     mt: &MemTable<T>,
+    limits: TqlLimits,
 ) -> Result<
     (
         crate::query::pipeline::NodeSet,
@@ -225,7 +397,7 @@ fn execute_pipeline_set<T: VectorType>(
                 source_query.limit = None;
                 source_query.offset = None;
                 source_query.returns = ReturnClause::All;
-                let ids = execute_tql(&source_query, mt)?
+                let ids = execute_tql_with_limits(&source_query, mt, limits)?
                     .into_iter()
                     .flat_map(|row| row.into_values().map(|node| node.id))
                     .collect();
@@ -502,6 +674,7 @@ fn execute_pipeline_set<T: VectorType>(
 fn execute_pipeline_node_query<T: VectorType>(
     query: &TqlQuery,
     mt: &MemTable<T>,
+    limits: TqlLimits,
 ) -> Result<TqlResult<T>, TriviumError> {
     if matches!(&query.returns, ReturnClause::Expressions(items) if items.iter().any(|item| matches!(item.kind, ReturnExprKind::Scalar(_))))
     {
@@ -509,7 +682,7 @@ fn execute_pipeline_node_query<T: VectorType>(
             "节点结果 API 无法承载标量列，请使用 tql_values (Node-only result API cannot carry scalar columns; use tql_values)".into(),
         ));
     }
-    let (set, current_name, scalar_aliases) = execute_pipeline_set(query, mt)?;
+    let (set, current_name, scalar_aliases) = execute_pipeline_set(query, mt, limits)?;
     let mut pipeline_rows = set.rows().to_vec();
     sort_pipeline_rows(&mut pipeline_rows, &query.order_by, &scalar_aliases, mt);
     apply_offset_limit(&mut pipeline_rows, query.offset, query.limit);
@@ -523,13 +696,22 @@ fn execute_pipeline_node_query<T: VectorType>(
     Ok(results)
 }
 
-/// 执行 TQL 并返回可同时承载节点与标量列的一等值结果。
+/// 执行 TQL 并返回可同时承载节点与标量列的一等值结果（使用默认行数配额）。
 pub fn execute_tql_values<T: VectorType>(
     query: &TqlQuery,
     mt: &MemTable<T>,
 ) -> Result<TqlValueResult<T>, TriviumError> {
+    execute_tql_values_with_limits(query, mt, TqlLimits::default())
+}
+
+/// 执行 TQL 返回一等值结果，并指定行数配额。
+pub fn execute_tql_values_with_limits<T: VectorType>(
+    query: &TqlQuery,
+    mt: &MemTable<T>,
+    limits: TqlLimits,
+) -> Result<TqlValueResult<T>, TriviumError> {
     if query.pipeline.is_empty() {
-        return execute_tql(query, mt).map(|rows| {
+        return execute_tql_with_limits(query, mt, limits).map(|rows| {
             rows.into_iter()
                 .map(|row| {
                     row.into_iter()
@@ -539,7 +721,7 @@ pub fn execute_tql_values<T: VectorType>(
                 .collect()
         });
     }
-    let (set, current_name, scalar_aliases) = execute_pipeline_set(query, mt)?;
+    let (set, current_name, scalar_aliases) = execute_pipeline_set(query, mt, limits)?;
     let mut rows = set.rows().to_vec();
     if pipeline_has_aggregation(&query.returns) {
         let mut values =
@@ -1227,6 +1409,7 @@ fn execute_match<T: VectorType>(
     query: &TqlQuery,
     mt: &MemTable<T>,
     row_limit: usize,
+    step_budget: usize,
     optional: bool,
 ) -> Result<TqlResult<T>, TriviumError> {
     // 建立变量映射
@@ -1271,7 +1454,7 @@ fn execute_match<T: VectorType>(
             start_id,
             &mut results,
             &mut budget,
-            MAX_BUDGET,
+            step_budget,
             row_limit,
         )?;
         if !cont {
@@ -2989,9 +3172,9 @@ fn execute_set<T: VectorType>(
         .as_ref()
         .ok_or_else(|| TriviumError::QueryParse("SET requires a preceding MATCH clause".into()))?;
 
-    // 运行 MATCH 查询获取匹配行
+    // 运行 MATCH 查询获取匹配行（不设默认上限：截断会导致静默的部分更新）
     let query = build_match_query(&source.pattern, source.predicate.as_ref());
-    let results = execute_tql(&query, mt)?;
+    let results = execute_tql_with_limits(&query, mt, TqlLimits::UNLIMITED)?;
 
     let mut ops = Vec::new();
 
@@ -3025,8 +3208,9 @@ fn execute_delete<T: VectorType>(
         TriviumError::QueryParse("DELETE requires a preceding MATCH clause".into())
     })?;
 
+    // 不设默认上限：截断会导致静默的部分删除
     let query = build_match_query(&source.pattern, source.predicate.as_ref());
-    let results = execute_tql(&query, mt)?;
+    let results = execute_tql_with_limits(&query, mt, TqlLimits::UNLIMITED)?;
 
     let mut ops = Vec::new();
     let mut deleted: HashSet<NodeId> = HashSet::new();

--- a/src/storage/memtable.rs
+++ b/src/storage/memtable.rs
@@ -2262,9 +2262,16 @@ impl<T: VectorType> MemTable<T> {
         self.payloads.contains_key(&id)
     }
 
-    /// 返回所有活跃节点 ID
+    /// 返回所有活跃节点 ID，**按 ID 升序**。
+    ///
+    /// 排序是契约而非实现细节：`payloads` 是 `HashMap`，裸迭代顺序随进程重启变化、
+    /// 且在扩容时整体重排。全表扫描（`planner::materialize_full_scan`）、TQL 的
+    /// `OFFSET` 分页、以及 `planner::difference_sorted`（双指针归并，要求两侧升序）
+    /// 都依赖此顺序的确定性。
     pub fn all_node_ids(&self) -> Vec<NodeId> {
-        self.payloads.keys().cloned().collect()
+        let mut ids: Vec<NodeId> = self.payloads.keys().cloned().collect();
+        ids.sort_unstable();
+        ids
     }
 
     /// 返回包含逻辑删除（tombstones）在内的完整内部 ID 阵列，

--- a/stubtest-allowlist.txt
+++ b/stubtest-allowlist.txt
@@ -15,4 +15,4 @@
 # so the inner module needs no stub of its own. Ignoring it lets stubtest check
 # the entire public surface strictly while skipping only this layout artifact.
 triviumdb\.triviumdb
-triviumdb\.(Vector|DType|SyncMode|AccessMode|MissingIndexPolicy|EdgeDirection|ReachabilityDirection)
+triviumdb\.(Vector|DType|SyncMode|AccessMode|MissingIndexPolicy|EdgeDirection|ReachabilityDirection|RowOverflowPolicy)

--- a/tests/security.rs
+++ b/tests/security.rs
@@ -8,7 +8,7 @@
 
 use std::fs::OpenOptions;
 use std::io::Write;
-use triviumdb::database::Database;
+use triviumdb::database::{Config, Database, RowOverflowPolicy};
 use triviumdb::storage::wal::WalEntry;
 
 const DIM: usize = 2;
@@ -196,7 +196,12 @@ fn 测试_密集图谱_万级笛卡尔积防OOM_LazyEvaluation有效性() {
     let path = tmp_db("dense_graph_oom");
     cleanup(&path);
 
-    let mut db = Database::<f32>::open(&path, DIM).unwrap();
+    let config = Config {
+        dim: DIM,
+        row_overflow: RowOverflowPolicy::Break,
+        ..Default::default()
+    };
+    let mut db = Database::<f32>::open_with_config(&path, config).unwrap();
 
     // 构造一个超级中心节点 (0)
     let hub_id = db

--- a/tests/tql_row_limit.rs
+++ b/tests/tql_row_limit.rs
@@ -1,0 +1,776 @@
+#![allow(non_snake_case)]
+//! TQL 行数上限与分页回归测试（Issue #32）
+//!
+//! 覆盖四个原始缺陷：
+//! 1. 显式 LIMIT 被夹到 5000
+//! 2. OFFSET 无法翻页（`OFFSET 5000` 返回 0 行）
+//! 3. 聚合 / ORDER BY 因输入被截断而返回错误答案
+//! 4. 全表扫描顺序随机，截断得到任意交错子集
+//!
+//! 同时验证含边模式的 DoS 保护未被削弱。
+
+use std::collections::HashSet;
+use triviumdb::database::{Config, Database, RowOverflowPolicy, StorageMode};
+use triviumdb::query::tql_executor::TqlValue;
+
+const DIM: usize = 2;
+
+/// 超过 DEFAULT_ROW_LIMIT(5000) 的节点数，用于触发原 bug
+const N: usize = 6000;
+
+fn tmp_db(name: &str) -> String {
+    let dir = std::env::temp_dir().join("triviumdb_test");
+    std::fs::create_dir_all(&dir).ok();
+    dir.join(format!("rowlimit_{}", name))
+        .to_string_lossy()
+        .to_string()
+}
+
+fn cleanup(path: &str) {
+    for ext in &["", ".wal", ".vec", ".lock", ".flush_ok"] {
+        std::fs::remove_file(format!("{}{}", path, ext)).ok();
+    }
+}
+
+/// 建库并插入 N 个节点，id 为 1..=N，score 随 id 递增。
+fn build_db_with(name: &str, config: Config) -> (Database<f32>, String) {
+    let path = tmp_db(name);
+    cleanup(&path);
+    let mut db = Database::<f32>::open_with_config(&path, config).unwrap();
+    for i in 1..=N {
+        db.insert_with_id(
+            i as u64,
+            &[i as f32, 0.0],
+            serde_json::json!({"type": "memory", "label": format!("n{i}"), "score": i}),
+        )
+        .unwrap();
+    }
+    assert_eq!(db.node_count(), N, "前置条件：插入了 {N} 个节点");
+    (db, path)
+}
+
+fn default_config() -> Config {
+    Config {
+        dim: DIM,
+        storage_mode: StorageMode::Rom,
+        ..Default::default()
+    }
+}
+
+fn build_db(name: &str) -> (Database<f32>, String) {
+    build_db_with(name, default_config())
+}
+
+/// 从 tql_values 结果里取聚合计数。
+///
+/// 非管道聚合经 `tql_values` 会包一层 Node，计数落在 payload 里；管道聚合直接给 Int。
+fn extract_count(rows: &[std::collections::HashMap<String, TqlValue<f32>>], alias: &str) -> i64 {
+    assert_eq!(rows.len(), 1, "聚合应返回单行");
+    match rows[0].get(alias) {
+        Some(TqlValue::Int(count)) => *count,
+        Some(TqlValue::Node(node)) => node
+            .payload
+            .get(alias)
+            .and_then(|value| value.as_i64())
+            .unwrap_or_else(|| panic!("Node payload 应带 {alias} 计数")),
+        other => panic!("期望 {alias} 是计数，实得 {other:?}"),
+    }
+}
+
+// ════════ 缺陷 1/4：全量枚举 ════════
+
+#[test]
+fn 测试_MATCH全量枚举_不再截断在5000() {
+    let (db, path) = build_db("match_full");
+
+    let rows = db.tql("MATCH (n) RETURN n").unwrap();
+    assert_eq!(
+        rows.len(),
+        N,
+        "无边模式 MATCH (n) 行数被节点数天然界定，应全量返回而非截断在 5000"
+    );
+
+    // 返回的 id 必须正好是全集，不能是任意交错子集
+    let ids: HashSet<u64> = rows
+        .iter()
+        .filter_map(|row| row.get("n").map(|node| node.id))
+        .collect();
+    let expected: HashSet<u64> = (1..=N as u64).collect();
+    assert_eq!(ids, expected, "返回的 id 集合应与 1..=N 完全一致");
+
+    drop(db);
+    cleanup(&path);
+}
+
+#[test]
+fn 测试_FIND全量枚举_不再截断在5000() {
+    let (db, path) = build_db("find_full");
+
+    let rows = db.tql(r#"FIND {type: "memory"} RETURN *"#).unwrap();
+    assert_eq!(rows.len(), N, "FIND 命中全部 {N} 个节点，应全量返回");
+
+    drop(db);
+    cleanup(&path);
+}
+
+// ════════ 缺陷 1：显式 LIMIT ════════
+
+#[test]
+fn 测试_显式LIMIT不再被夹到5000() {
+    let (db, path) = build_db("explicit_limit");
+
+    // 原 bug：.min(DEFAULT_ROW_LIMIT) 把 20000 改写成 5000
+    let rows = db.tql("MATCH (n) RETURN n LIMIT 20000").unwrap();
+    assert_eq!(rows.len(), N, "LIMIT 大于节点数时应返回全部 {N} 行");
+
+    // 介于 5000 与 N 之间的 LIMIT 必须精确生效
+    let rows = db.tql("MATCH (n) RETURN n LIMIT 5500").unwrap();
+    assert_eq!(rows.len(), 5500, "LIMIT 5500 应精确返回 5500 行");
+
+    // 小于 5000 的 LIMIT 行为不变
+    let rows = db.tql("MATCH (n) RETURN n LIMIT 10").unwrap();
+    assert_eq!(rows.len(), 10, "小 LIMIT 行为保持不变");
+
+    drop(db);
+    cleanup(&path);
+}
+
+// ════════ 缺陷 2：OFFSET 分页 ════════
+
+#[test]
+fn 测试_OFFSET可翻页至末尾() {
+    let (db, path) = build_db("offset_paging");
+
+    // 原 bug：扫 5000 行后跳过 5000 行 → 0 行
+    let rows = db.tql("MATCH (n) RETURN n OFFSET 5000").unwrap();
+    assert_eq!(rows.len(), N - 5000, "OFFSET 5000 应返回剩余 1000 行而非 0 行");
+
+    // 原 bug：6000.min(5000)=5000，扫 5000 跳 4000 → 1000 行
+    let rows = db.tql("MATCH (n) RETURN n LIMIT 2000 OFFSET 4000").unwrap();
+    assert_eq!(
+        rows.len(),
+        2000,
+        "LIMIT 2000 OFFSET 4000（合计 6000）应返回完整的 2000 行"
+    );
+
+    // limit + offset 超过实际节点数时，返回剩余全部（这里 6000-3000=3000）
+    let rows = db.tql("MATCH (n) RETURN n LIMIT 4000 OFFSET 3000").unwrap();
+    assert_eq!(
+        rows.len(),
+        N - 3000,
+        "OFFSET 3000 之后只剩 3000 行可返回"
+    );
+
+    // 末页边界：OFFSET 恰好等于总数 → 空结果，不报错
+    let rows = db.tql(&format!("MATCH (n) RETURN n OFFSET {N}")).unwrap();
+    assert!(rows.is_empty(), "OFFSET 等于总行数应返回空结果");
+
+    drop(db);
+    cleanup(&path);
+}
+
+#[test]
+fn 测试_分页完整性_无重复无遗漏() {
+    let (db, path) = build_db("paging_complete");
+
+    const PAGE: usize = 1000;
+    let mut seen: Vec<u64> = Vec::new();
+    let mut offset = 0;
+    while offset < N {
+        let rows = db
+            .tql(&format!("MATCH (n) RETURN n LIMIT {PAGE} OFFSET {offset}"))
+            .unwrap();
+        assert!(
+            !rows.is_empty(),
+            "offset={offset} 时页面不应为空，否则无法翻到末尾"
+        );
+        seen.extend(rows.iter().filter_map(|row| row.get("n").map(|n| n.id)));
+        offset += PAGE;
+    }
+
+    assert_eq!(seen.len(), N, "所有页面合计应为 {N} 行（无遗漏）");
+    let unique: HashSet<u64> = seen.iter().copied().collect();
+    assert_eq!(unique.len(), N, "跨页不应出现重复 id");
+    assert_eq!(
+        unique,
+        db.all_node_ids().into_iter().collect::<HashSet<u64>>(),
+        "分页并集应等于 all_node_ids() 全集"
+    );
+
+    drop(db);
+    cleanup(&path);
+}
+
+// ════════ 缺陷 3：聚合与排序的正确性 ════════
+
+#[test]
+fn 测试_聚合count超过5000返回正确值() {
+    let (db, path) = build_db("agg_count");
+
+    // 原 bug：输入被硬限在 5000，count 返回 5000 —— 这是错的答案，不是截断
+    let rows = db.tql_values("MATCH (n) RETURN count(n) AS c").unwrap();
+    assert_eq!(
+        extract_count(&rows, "c"),
+        N as i64,
+        "count(n) 应等于真实节点数 {N}"
+    );
+
+    drop(db);
+    cleanup(&path);
+}
+
+#[test]
+fn 测试_ORDER_BY_LIMIT取到真正的TopN() {
+    let (db, path) = build_db("order_top_n");
+
+    // 原 bug：只对任意 5000 行排序，top-10 可能完全错
+    let rows = db
+        .tql("MATCH (n) RETURN n ORDER BY n.score DESC LIMIT 10")
+        .unwrap();
+    assert_eq!(rows.len(), 10, "应返回 10 行");
+
+    let ids: Vec<u64> = rows
+        .iter()
+        .filter_map(|row| row.get("n").map(|node| node.id))
+        .collect();
+    let expected: Vec<u64> = (1..=N as u64).rev().take(10).collect();
+    assert_eq!(
+        ids, expected,
+        "score 随 id 递增，故 DESC 的 top-10 必须是最大的 10 个 id"
+    );
+
+    drop(db);
+    cleanup(&path);
+}
+
+// ════════ 缺陷 4：扫描顺序确定性 ════════
+
+#[test]
+fn 测试_全表扫描顺序按id升序() {
+    let (db, path) = build_db("scan_order");
+
+    let ids = db.all_node_ids();
+    let mut sorted = ids.clone();
+    sorted.sort_unstable();
+    assert_eq!(ids, sorted, "all_node_ids() 必须升序");
+
+    // 截断出来的必须是最小的 3 个 id，而不是任意交错子集
+    let rows = db.tql("MATCH (n) RETURN n LIMIT 3").unwrap();
+    let ids: Vec<u64> = rows
+        .iter()
+        .filter_map(|row| row.get("n").map(|node| node.id))
+        .collect();
+    assert_eq!(ids, vec![1, 2, 3], "LIMIT 3 应稳定返回最小的 3 个 id");
+
+    drop(db);
+    cleanup(&path);
+}
+
+// ════════ DoS 保护未被削弱 ════════
+
+/// 建一个笛卡尔积图：中心节点 + `leaves` 个叶子双向连边。
+/// `MATCH (a)-[:connects]->(b)-[:connects]->(c)` 的路径数为 leaves² + leaves。
+fn build_cartesian_db(name: &str, config: Config, leaves: usize) -> (Database<f32>, String) {
+    let path = tmp_db(name);
+    cleanup(&path);
+    let mut db = Database::<f32>::open_with_config(&path, config).unwrap();
+
+    let hub = db
+        .insert(&[0.0, 0.0], serde_json::json!({"name": "hub"}))
+        .unwrap();
+    let mut leaf_ids = Vec::new();
+    for i in 1..=leaves {
+        leaf_ids.push(
+            db.insert(&[i as f32, 0.0], serde_json::json!({"name": "leaf"}))
+                .unwrap(),
+        );
+    }
+    {
+        let mut tx = db.begin_tx();
+        for &leaf in &leaf_ids {
+            tx.link(leaf, hub, "connects", 1.0);
+            tx.link(hub, leaf, "connects", 1.0);
+        }
+        tx.commit().unwrap();
+    }
+    (db, path)
+}
+
+const CARTESIAN_QUERY: &str = "MATCH (a)-[:connects]->(b)-[:connects]->(c) RETURN c";
+
+#[test]
+fn 测试_含边模式无LIMIT默认报错() {
+    // 100 个叶子 → 10,100 条路径，超过 5,000 默认上限
+    let (db, path) = build_cartesian_db("cartesian_throw", default_config(), 100);
+
+    let result = db.tql(CARTESIAN_QUERY);
+    assert!(
+        result.is_err(),
+        "默认 Throw 策略下，含边模式触及默认上限应报错而非静默返回 5000 行子集"
+    );
+    let message = result.unwrap_err().to_string();
+    assert!(
+        message.contains("5000") && message.contains("截断"),
+        "错误信息应说明在哪一行被截断，实得：{message}"
+    );
+
+    drop(db);
+    cleanup(&path);
+}
+
+#[test]
+fn 测试_Break策略下截断为告警并返回部分结果() {
+    let config = Config {
+        row_overflow: RowOverflowPolicy::Break,
+        ..default_config()
+    };
+    let (db, path) = build_cartesian_db("cartesian_break", config, 100);
+
+    let rows = db
+        .tql(CARTESIAN_QUERY)
+        .expect("Break 策略下截断只告警，不应报错");
+    assert_eq!(
+        rows.len(),
+        5000,
+        "Break 策略保留旧的「优雅截断」行为，作为迁移出口"
+    );
+
+    drop(db);
+    cleanup(&path);
+}
+
+#[test]
+fn 测试_含边模式未触及上限时不报错() {
+    // 20 个叶子 → 420 条路径，远低于 5,000，不该被误报截断
+    let (db, path) = build_cartesian_db("cartesian_under_cap", default_config(), 20);
+
+    let rows = db
+        .tql(CARTESIAN_QUERY)
+        .expect("未触及上限的含边查询不应报错");
+    assert_eq!(rows.len(), 20 * 20 + 20, "应返回全部 420 条路径");
+
+    drop(db);
+    cleanup(&path);
+}
+
+#[test]
+fn 测试_恰好等于上限不误报截断() {
+    // 探针判据的关键回归：结果正好等于上限时，len() == cap 的旧判据会误报
+    let config = Config {
+        max_query_rows: Some(N),
+        ..default_config()
+    };
+    let path = tmp_db("exact_cap");
+    cleanup(&path);
+    let mut db = Database::<f32>::open_with_config(&path, config).unwrap();
+    for i in 1..=N {
+        db.insert_with_id(i as u64, &[i as f32, 0.0], serde_json::json!({"seq": i}))
+            .unwrap();
+    }
+
+    let rows = db
+        .tql("MATCH (n) RETURN n")
+        .expect("结果恰好等于上限不是截断，不应报错");
+    assert_eq!(rows.len(), N, "应返回全部 {N} 行");
+
+    drop(db);
+    cleanup(&path);
+}
+
+#[test]
+fn 测试_throw模式下默认上限截断返回错误() {
+    let path = tmp_db("throw_mode");
+    cleanup(&path);
+    let config = Config {
+        row_overflow: RowOverflowPolicy::Throw,
+        ..default_config()
+    };
+    let mut db = Database::<f32>::open_with_config(&path, config).unwrap();
+
+    let hub = db.insert(&[0.0, 0.0], serde_json::json!({"name": "hub"})).unwrap();
+    let mut leaves = Vec::new();
+    for i in 1..=100 {
+        leaves.push(
+            db.insert(&[i as f32, 0.0], serde_json::json!({"name": "leaf"}))
+                .unwrap(),
+        );
+    }
+    {
+        let mut tx = db.begin_tx();
+        for &leaf in &leaves {
+            tx.link(leaf, hub, "connects", 1.0);
+            tx.link(hub, leaf, "connects", 1.0);
+        }
+        tx.commit().unwrap();
+    }
+
+    let result = db.tql("MATCH (a)-[:connects]->(b)-[:connects]->(c) RETURN c");
+    assert!(
+        result.is_err(),
+        "throw 模式下被默认上限截断应返回错误而非静默子集"
+    );
+
+    // 显式 LIMIT 是用户自己的意图，不应报错
+    let rows = db
+        .tql("MATCH (a)-[:connects]->(b)-[:connects]->(c) RETURN c LIMIT 100")
+        .unwrap();
+    assert_eq!(rows.len(), 100, "显式 LIMIT 在 throw 模式下不算截断");
+
+    drop(db);
+    cleanup(&path);
+}
+
+// ════════ 可配置性 ════════
+
+#[test]
+fn 测试_max_query_rows可配置() {
+    let path = tmp_db("configurable_cap");
+    cleanup(&path);
+    let config = Config {
+        max_query_rows: Some(100),
+        row_overflow: RowOverflowPolicy::Break,
+        ..default_config()
+    };
+    let mut db = Database::<f32>::open_with_config(&path, config).unwrap();
+    for i in 1..=N {
+        db.insert_with_id(i as u64, &[i as f32, 0.0], serde_json::json!({"seq": i}))
+            .unwrap();
+    }
+
+    let rows = db.tql("MATCH (n) RETURN n").unwrap();
+    assert_eq!(rows.len(), 100, "显式配置 max_query_rows=100 应对无边模式也生效");
+
+    // 显式 LIMIT 仍优先于配置
+    let rows = db.tql("MATCH (n) RETURN n LIMIT 300").unwrap();
+    assert_eq!(rows.len(), 300, "显式 LIMIT 优先于 max_query_rows");
+
+    drop(db);
+    cleanup(&path);
+}
+
+#[test]
+fn 测试_max_query_rows为0表示不限() {
+    let path = tmp_db("uncapped");
+    cleanup(&path);
+    let config = Config {
+        max_query_rows: Some(0),
+        ..default_config()
+    };
+    let mut db = Database::<f32>::open_with_config(&path, config).unwrap();
+
+    let hub = db.insert(&[0.0, 0.0], serde_json::json!({"name": "hub"})).unwrap();
+    let mut leaves = Vec::new();
+    for i in 1..=30 {
+        leaves.push(
+            db.insert(&[i as f32, 0.0], serde_json::json!({"name": "leaf"}))
+                .unwrap(),
+        );
+    }
+    {
+        let mut tx = db.begin_tx();
+        for &leaf in &leaves {
+            tx.link(leaf, hub, "connects", 1.0);
+            tx.link(hub, leaf, "connects", 1.0);
+        }
+        tx.commit().unwrap();
+    }
+
+    // 30*30 + 30 = 930 条路径，全部返回（不再被 5000 之外的默认上限影响，
+    // 这里主要验证 Some(0) 分支不会把上限设成 0 行）
+    let rows = db
+        .tql("MATCH (a)-[:connects]->(b)-[:connects]->(c) RETURN c")
+        .unwrap();
+    assert_eq!(rows.len(), 930, "max_query_rows=0 表示不设默认上限");
+
+    drop(db);
+    cleanup(&path);
+}
+
+// ════════ 聚合正确性：截断会让答案「错」而不只是「少」 ════════
+
+#[test]
+fn 测试_含边模式聚合触及上限时报错而非返回错答案() {
+    // 10,100 条路径 > 5,000 默认上限。count 若只数 5,000 就是错的答案，
+    // 不是部分答案——必须报错。
+    let (db, path) = build_cartesian_db("agg_edge_throw", default_config(), 100);
+
+    let result = db.tql_values("MATCH (a)-[:connects]->(b) RETURN count(b) AS c");
+    match result {
+        Err(err) => {
+            let message = err.to_string();
+            assert!(
+                message.contains("错误") || message.contains("WRONG"),
+                "聚合被截断时错误信息应说明结果是错的而非仅不完整，实得：{message}"
+            );
+        }
+        Ok(rows) => {
+            // 200 条边 < 5000，这条查询本不该触及上限；若真返回了就必须是正确值
+            let count = extract_count(&rows, "c");
+            assert_eq!(count, 200, "未触及上限时 count 必须准确");
+        }
+    }
+
+    drop(db);
+    cleanup(&path);
+}
+
+#[test]
+fn 测试_ORDER_BY带OFFSET时预算包含offset() {
+    // P1-c 回归：requires_full_input 分支此前不把 offset 计入预算，
+    // 导致 `ORDER BY .. OFFSET k` 把预算耗在被跳过的行上而返回不足一页。
+    let config = Config {
+        max_query_rows: Some(2000),
+        row_overflow: RowOverflowPolicy::Break,
+        ..default_config()
+    };
+    let path = tmp_db("order_offset_budget");
+    cleanup(&path);
+    let mut db = Database::<f32>::open_with_config(&path, config).unwrap();
+    for i in 1..=N {
+        db.insert_with_id(
+            i as u64,
+            &[i as f32, 0.0],
+            serde_json::json!({"score": i}),
+        )
+        .unwrap();
+    }
+
+    // 上限 2000 + offset 1500 → 预算 3500，跳过 1500 后应仍有整整 2000 行
+    let rows = db
+        .tql("MATCH (n) RETURN n ORDER BY n.score OFFSET 1500")
+        .unwrap();
+    assert_eq!(
+        rows.len(),
+        2000,
+        "offset 应叠加进预算，而非从上限里扣掉"
+    );
+
+    drop(db);
+    cleanup(&path);
+}
+
+// ════════ 内存护栅 ════════
+
+/// 建一个高维库并在**装载完成后**再设内存预算。
+///
+/// `memory_limit` 同时管写入容量，开库即设小预算会让 insert 直接被拒
+/// （`CapacityReservationRejected`），所以只能事后调。
+fn build_high_dim_db(name: &str, overflow: RowOverflowPolicy) -> (Database<f32>, String) {
+    let path = tmp_db(name);
+    cleanup(&path);
+    let config = Config {
+        dim: 1536,
+        storage_mode: StorageMode::Rom,
+        auto_build_quiver: false,
+        row_overflow: overflow,
+        ..Default::default()
+    };
+    let mut db = Database::<f32>::open_with_config(&path, config).unwrap();
+    let vector = vec![0.1f32; 1536];
+    for i in 1..=500u64 {
+        db.insert_with_id(i, &vector, serde_json::json!({"t": "m"}))
+            .unwrap();
+    }
+    // dim=1536 f32 → 每行约 6KiB + 开销；512KiB 只够几十行
+    db.set_memory_limit(512 * 1024);
+    (db, path)
+}
+
+#[test]
+fn 测试_内存护栅触发时报错() {
+    let (db, path) = build_high_dim_db("memory_guard", RowOverflowPolicy::Throw);
+
+    let message = db
+        .tql("MATCH (n) RETURN n")
+        .expect_err("结果集超过内存预算应报错，而不是物化到 OOM")
+        .to_string();
+    assert!(
+        message.contains("内存预算") || message.contains("memory budget"),
+        "错误信息应指明是内存预算导致的，实得：{message}"
+    );
+
+    drop(db);
+    cleanup(&path);
+}
+
+#[test]
+fn 测试_内存护栅在Break策略下降级为截断() {
+    let (db, path) = build_high_dim_db("memory_guard_break", RowOverflowPolicy::Break);
+
+    let rows = db.tql("MATCH (n) RETURN n").unwrap();
+    assert!(
+        !rows.is_empty() && rows.len() < 500,
+        "Break 策略下应截断到预算内的行数，实得 {} 行",
+        rows.len()
+    );
+
+    drop(db);
+    cleanup(&path);
+}
+
+#[test]
+fn 测试_内存护栅下显式LIMIT仍受约束() {
+    // 内存是硬约束：显式 LIMIT 比预算大时，仍按预算截断并告知
+    let (db, path) = build_high_dim_db("memory_guard_limit", RowOverflowPolicy::Throw);
+
+    let result = db.tql("MATCH (n) RETURN n LIMIT 500");
+    assert!(
+        result.is_err(),
+        "显式 LIMIT 不能突破内存预算——否则护栅形同虚设"
+    );
+
+    // 预算内的 LIMIT 正常工作
+    let rows = db.tql("MATCH (n) RETURN n LIMIT 10").unwrap();
+    assert_eq!(rows.len(), 10, "预算内的小 LIMIT 应正常返回");
+
+    drop(db);
+    cleanup(&path);
+}
+
+#[test]
+fn 测试_内存预算充足时不误伤() {
+    // dim=2 的库，同样 512KiB 预算能放数万行，不该触发
+    let path = tmp_db("memory_guard_ample");
+    cleanup(&path);
+    let config = Config {
+        memory_limit: 512 * 1024,
+        ..default_config()
+    };
+    let mut db = Database::<f32>::open_with_config(&path, config).unwrap();
+    for i in 1..=1000u64 {
+        db.insert_with_id(i, &[i as f32, 0.0], serde_json::json!({"t": "m"}))
+            .unwrap();
+    }
+
+    let rows = db.tql("MATCH (n) RETURN n").unwrap();
+    assert_eq!(rows.len(), 1000, "小维度下预算充足，不应触发护栅");
+
+    drop(db);
+    cleanup(&path);
+}
+
+// ════════ 相邻问题 ════════
+
+#[test]
+fn 测试_WITH管道源集合不再被截断() {
+    let (db, path) = build_db("pipeline_source");
+
+    let rows = db.tql("MATCH (n) AS source WITH source RETURN source").unwrap();
+    assert_eq!(rows.len(), N, "管道的源集合此前同样被静默截断在 5000");
+
+    drop(db);
+    cleanup(&path);
+}
+
+#[test]
+fn 测试_DML的MATCH不会因默认上限部分生效() {
+    let (mut db, path) = build_db("dml_full");
+
+    // 原本 SET 的 MATCH 走默认上限，超过 5000 的匹配集会被静默截断，
+    // 造成只更新一部分节点。
+    let result = db.tql_mut(r#"MATCH (n) WHERE n.type == "memory" SET n.touched == 1"#);
+    match result {
+        Ok(mutation) => assert_eq!(
+            mutation.affected, N,
+            "SET 应作用于全部 {N} 个匹配节点，不能只改前 5000 个"
+        ),
+        Err(err) => panic!("DML 执行失败: {err}"),
+    }
+
+    drop(db);
+    cleanup(&path);
+}
+
+#[test]
+fn 测试_bitmap取反过滤依赖升序universe() {
+    let path = tmp_db("bitmap_ne");
+    cleanup(&path);
+    let mut db = Database::<f32>::open_with_config(&path, default_config()).unwrap();
+
+    for i in 1..=200u64 {
+        let kind = if i % 2 == 0 { "even" } else { "odd" };
+        db.insert_with_id(i, &[i as f32, 0.0], serde_json::json!({"kind": kind}))
+            .unwrap();
+    }
+    db.create_index("kind").unwrap();
+
+    // difference_sorted 是双指针归并，universe 无序会漏掉本该排除的行
+    let rows = db.tql(r#"FIND {kind: {$ne: "even"}} RETURN *"#).unwrap();
+    assert_eq!(rows.len(), 100, "$ne 应精确返回 100 个 odd 节点");
+    for row in &rows {
+        for node in row.values() {
+            assert_eq!(
+                node.payload.get("kind").and_then(|v| v.as_str()),
+                Some("odd"),
+                "$ne 结果不应包含被排除的 even 节点（id={}）",
+                node.id
+            );
+        }
+    }
+
+    drop(db);
+    cleanup(&path);
+}
+
+// ════════ 10 万节点边界：步数预算不得拦线性扫描 ════════
+
+/// 这组测试锁定第一轮实现里被漏掉的缺陷：解除行数上限后，`tql_dfs` 的
+/// 步数预算（MAX_BUDGET = 100,000，每访问一个节点 +1）成了新的隐形天花板，
+/// 使 10 万节点以上的 `MATCH (n)` 从「静默返回 5000 行」变成「直接报错」。
+///
+/// 标 `#[ignore]`：插入 10 万节点需数秒，用
+/// `cargo test --release --test tql_row_limit -- --ignored` 显式跑。
+#[test]
+#[ignore]
+fn 测试_十万节点以上全扫不撞步数预算() {
+    const BIG: usize = 100_001;
+    let path = tmp_db("beyond_step_budget");
+    cleanup(&path);
+    let mut db = Database::<f32>::open_with_config(&path, default_config()).unwrap();
+    for i in 1..=BIG {
+        db.insert_with_id(i as u64, &[i as f32, 0.0], serde_json::json!({"t": "m"}))
+            .unwrap();
+    }
+
+    let rows = db
+        .tql("MATCH (n) RETURN n")
+        .expect("无边全扫的成本是线性的，不该被边展开预算拦住");
+    assert_eq!(rows.len(), BIG, "应返回全部 {BIG} 行");
+
+    let rows = db
+        .tql(r#"FIND {t: "m"} RETURN *"#)
+        .expect("FIND 同样不该被隐式硬顶截断");
+    assert_eq!(rows.len(), BIG, "FIND 应返回全部 {BIG} 行，而非静默的 100,001 上限");
+
+    let rows = db
+        .tql_values("MATCH (n) RETURN count(n) AS c")
+        .expect("聚合不该因步数预算报错");
+    assert_eq!(
+        extract_count(&rows, "c"),
+        BIG as i64,
+        "count 应等于真实节点数"
+    );
+
+    drop(db);
+    cleanup(&path);
+}
+
+#[test]
+#[ignore]
+fn 测试_十五万节点FIND不被隐式硬顶截断() {
+    const BIG: usize = 150_000;
+    let path = tmp_db("no_hidden_ceiling");
+    cleanup(&path);
+    let mut db = Database::<f32>::open_with_config(&path, default_config()).unwrap();
+    for i in 1..=BIG {
+        db.insert_with_id(i as u64, &[i as f32, 0.0], serde_json::json!({"t": "m"}))
+            .unwrap();
+    }
+
+    // 第一轮实现里这里会静默返回 100,001 行（丢 5 万行）且不发告警
+    let rows = db.tql(r#"FIND {t: "m"} RETURN *"#).unwrap();
+    assert_eq!(rows.len(), BIG, "不应存在 MAX_BUDGET 派生的隐式行数硬顶");
+
+    drop(db);
+    cleanup(&path);
+}

--- a/triviumdb.d.ts
+++ b/triviumdb.d.ts
@@ -316,6 +316,21 @@ export interface TriviumDBOptions {
   accessMode?: 'readWrite' | 'readOnly' | 'immutable';
   /** Reader 遇到缺失或损坏 sidecar 时的行为 */
   missingIndexPolicy?: 'fallback' | 'buildInMemory' | 'error';
+  /**
+   * TQL 单次查询的默认行数上限，仅在查询未显式写 LIMIT 时生效。
+   *
+   * 省略时按风险区分：无边模式（`MATCH (n)`、`FIND`、`SEARCH`）不设默认上限，
+   * 含边模式默认 5,000 以防笛卡尔积爆炸。0 表示完全不限；n 表示一律不超过 n 行。
+   * 任何情况下仍受 100,000 步预算约束，显式 LIMIT 始终优先。
+   */
+  maxQueryRows?: number;
+  /**
+   * 结果因行数上限（而非显式 LIMIT）被截断时的行为，默认 'throw'（抛错）。
+   *
+   * 'throw' 宁可失败也不把子集伪装成全集（对齐 ClickHouse result_overflow_mode
+   * 的默认值）；'break' 截断并记录告警后返回部分结果。
+   */
+  rowOverflow?: 'throw' | 'break';
 }
 
 export class PreparedTql {


### PR DESCRIPTION
## 问题概述

Issue #32 报告了四个相互关联的缺陷：

1. **显式 LIMIT 被静默夹到 5000** — `LIMIT 10000` 实际只返回 5000 行
2. **OFFSET 分页失效** — `OFFSET 5000` 因扫描预算耗尽返回 0 行  
3. **聚合和排序返回错误答案** — `count(n)` 对 6000 个节点返回 5000
4. **全表扫描顺序随机** — HashMap 迭代序导致截断得到任意交错子集

原实现在 `tql_executor.rs:123` 用 `.min(DEFAULT_ROW_LIMIT)` 静默夹取所有查询的扫描预算，且 `all_node_ids()` 返回 HashMap 的随机迭代序。

---

## 核心修复

### 1. 扫描顺序确定化

```rust
// src/storage/memtable.rs:2266
pub fn all_node_ids(&self) -> Vec<NodeId> {
    let mut ids: Vec<NodeId> = self.payloads.keys().cloned().collect();
    ids.sort_unstable();
    ids
}
```

- 消除 HashMap 随机性，使 LIMIT/OFFSET 分页稳定可重现
- 附带修复 `difference_sorted` 的隐藏 bug（左输入无序导致 NEQ 过滤器可能漏排除）

### 2. 行数上限语义重构

替换原有的单一硬顶，改为三层优先级：

```
内存护栅 (硬约束，任何 LIMIT 都无法突破)
  └─> 显式 LIMIT (用户意图)
        └─> max_query_rows 配置 (管理员策略)
              └─> 默认上限 (风险分级)
```

**风险分级逻辑**：
- **无边模式**（`MATCH (n)` / `FIND {..}`）：行数天然被节点数界定，默认不设上限
- **含边模式**（`MATCH (a)-[..]->(b)`）：保留 5000 行保护，防笛卡尔积 DoS

用户可通过 `max_query_rows=0` 完全解除上限。

### 3. 聚合正确性保护

聚合/DISTINCT/ORDER BY 需全量输入才能给正确答案。原实现会在输入被截断时返回错误的 `count`/`sum` 结果。

**新行为**：
- **运行时探测**：扫描前尝试 1 步 DFS，若触边即判定为含边模式
- 含边 + 聚合 → 默认上限生效，但**报错而非返回错误答案**
- 错误消息区分「部分结果」vs「错误结果」

```rust
// src/query/tql_executor.rs:253-268
if results.len() >= execution_row_limit {
    let reason = if query.rank.is_some() || aggregates_or_distinct {
        "聚合/RANK/DISTINCT 被截断会导致错误答案"
    } else { "结果被截断为部分行" };
    // ...
}
```

### 4. 内存护栅

新增 `memory_limit` 配置，从结果集内存预算反推行数上限：

```rust
row_cap = memory_limit / (dim × sizeof(T) + payload_est + overhead)
```

- **硬约束**：显式 `LIMIT` 也无法突破
- 预算是保守估算（多变量模式只按 1 个节点算，投影裁剪的节省未计入），作为防 OOM 护栅足够

### 5. 溢出策略可配置

`RowOverflowPolicy` 替代旧的 `strict_row_limit: bool`：
- `Throw`（**新默认**）— 触限即报错，对齐 ClickHouse `result_overflow_mode` 和 ES `max_result_window` 的语义
- `Break` — 旧的优雅截断行为，记录 `tracing::warn!` 告警后返回部分结果

---

## 测试覆盖

新增 `tests/tql_row_limit.rs`（**26 个测试用例**，覆盖全部四个缺陷 + 保护机制不被削弱）：

### 原始缺陷回归测试
- ✅ 6000 节点 `MATCH (n)` 全量返回，不再截断在 5000
- ✅ 显式 `LIMIT 5500` / `20000` 精确生效
- ✅ `OFFSET 5000` 正确翻页，返回剩余 1000 行
- ✅ 分页完整性（1000 行/页 × 6 页 = 无重复无遗漏）
- ✅ 聚合 `count(n)` 返回真实值 6000
- ✅ `ORDER BY n.score DESC LIMIT 10` 取到真正的最大 10 个 id
- ✅ `all_node_ids()` 升序且稳定

### DoS 保护未被削弱
- ✅ 10 万步预算成功拦截 4 跳深度遍历
- ✅ 笛卡尔积模式（101×100 条路径）在 `Break` 策略下返回 5000 行
- ✅ 内存护栅：512 KiB 预算拦截大结果集（`LIMIT 10` 放行，`LIMIT 500` 报错）
- ✅ 含边 + 聚合触限报错而非返回错答案



```bash
cargo test --test tql_row_limit           # 24 passed
cargo test --test tql_row_limit --ignored # 2 passed (100k/150k 边界)
cargo test --lib --tests                  # 全量 68 个测试二进制，0 failures
cargo clippy --all-targets -- -D warnings # exit 0
```

---

## Breaking Changes

1. **默认策略改变**  
   v0.8.x：触限时 warn + 返回部分结果  
   v0.9.x：触限时 error + 拒绝查询  
   
   **迁移路径**：需要旧行为的用户显式传 `row_overflow="break"`

2. **API 变更**  
   移除：`TriviumDB(..., strict_row_limit=True)`  
   替换为：`row_overflow="throw"`（已是新默认，显式传参非必需）

3. **测试适配**  
   `tests/security.rs` 的笛卡尔积测试现在显式使用 `Break` 策略



Closes #32
