### PR TITLE
server: warm up QuIVer index in background on startup

### DIFF
--- a/crates/triviumdb-server/src/engine.rs
+++ b/crates/triviumdb-server/src/engine.rs
@@ -316,6 +316,31 @@ impl EngineHandle {
             max_write_batch_delay: config.max_write_batch_delay,
         });
         tokio::spawn(run_writer(inner.clone(), receiver));
+
+        // 后台预热 QuIVer 索引：重启后若库中已有大量向量节点（≥10_000），首次查询会触发
+        // 数秒的全量索引构建（auto_quiver_build_needed 门槛即 10k）。此处提前在后台构建，
+        // 把"首次查询卡 ~3s"变为启动后静默预热，查询路径只保留纯 HNSW 检索。
+        // build_quiver_index 内部走 snapshot + 无锁并行构建 + 瞬间 publish，不阻塞读写。
+        {
+            let warmup_db = Arc::clone(&inner.database);
+            tokio::task::spawn_blocking(move || {
+                let started = Instant::now();
+                let (nodes, built) = {
+                    let db = read_or_recover(&warmup_db);
+                    let nodes = db.node_count();
+                    let built = nodes >= 10_000 && db.build_quiver_index(None).is_ok();
+                    (nodes, built)
+                };
+                if built {
+                    tracing::info!(
+                        nodes,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        "QuIVer 索引后台预热完成 (background QuIVer index warmup finished)"
+                    );
+                }
+            });
+        }
+
         Ok(Self { inner, writes })
     }
 


### PR DESCRIPTION
## Summary

When `triviumdb-server` loads an existing database file that contains >=10k vector nodes, the **first** `/v1/search/vector` (or TQL `SEARCH`) request triggers a full QuIVer (Vamana) index build inside the read path. For 100k x 384d that takes ~3 seconds, so the very first latency probe looks catastrophic even though steady-state is ~4-8ms.

This PR warms up the QuIVer index in the background right after startup, so the first query no longer stalls on the one-time build.

## Root cause

- `MemTable::auto_quiver_build_needed()` (src/storage/memtable.rs) only auto-builds when `payloads.len() >= 10_000` and `quiver_index.is_none()`.
- The build is triggered lazily inside `execute_pipeline_with_limit` (src/database/pipeline.rs) on the first search — i.e. the first request pays the full build cost (~3s @ 100k nodes).
- `triviumdb-server` never calls the public `Database::build_quiver_index(None)` warm-up API, so every restart of a populated DB defers the 3s build to the first client query.

## Fix

In `EngineHandle::start` (crates/triviumdb-server/src/engine.rs), after the writer actor spawns, a `spawn_blocking` task calls `database.build_quiver_index(None)` when `node_count >= 10_000`.

`build_quiver_index` is already non-blocking by design (read-lock snapshot → lock-free parallel build → brief write-lock publish — same mechanism the query path's auto-build uses), so concurrent reads/writes are not stalled by the warm-up. The warm-up builds the same QuIVer index the query path's auto-build would have built — no second index type.

## Verified locally (Windows, 16 logical cores, 100k x 384d low-rank data)

| | cold start, first search | steady state |
|---|---|---|
| before | **2914 ms** | ~4 ms (embedded) / ~8 ms (HTTP) |
| after | **~150 ms** (query issued during warmup tail) → ~8 ms once warmup finishes | unchanged |

Also observed during investigation (not fixed here, worth separate issues):
- `RETURN b.id` / `RETURN DISTINCT b.id` in TQL returns 1 row instead of N (property resolution on node variables) — makes lightweight id-only graph queries impossible over HTTP.
- `FIND ... RETURN *` serializes every node with its full edge list into the JSON response (814 KB for LIMIT 100) — the server-side execution is ~0.4 ms but end-to-end is ~18 ms.
