### PR TITLE
test: verify nested JSON mutation parsing limit

### DIFF
--- a/tests/query/tql_parser.rs
+++ b/tests/query/tql_parser.rs
@@ -9,7 +9,7 @@
 
 use triviumdb::filter::Filter;
 use triviumdb::query::tql_ast::*;
-use triviumdb::query::tql_parser::parse_tql;
+use triviumdb::query::tql_parser::{parse_tql, parse_tql_statement};
 
 #[test]
 fn JSON数组嵌套超过解析预算时安全拒绝() {
@@ -20,7 +20,11 @@ fn JSON数组嵌套超过解析预算时安全拒绝() {
         "]".repeat(depth)
     );
 
-    assert!(parse_tql(&query).is_err(), "超深 JSON 数组必须安全拒绝");
+    let error = parse_tql_statement(&query).expect_err("超深 JSON 数组必须安全拒绝");
+    assert!(
+        error.contains("JSON nesting too deep"),
+        "应由 JSON 递归预算拒绝，实际错误：{error}"
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- exercise the same mutation parser entry point used by fuzzing
- assert that excessive JSON nesting is rejected by the recursion budget

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace -- --test-threads=1