### PR TITLE
fix: unblock the v0.8.6 release quality gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
           cargo check --lib --features nodejs
           cargo test --workspace -- --test-threads=1
           cargo clippy --workspace --all-targets -- -D warnings
-          npm ci
+          npm install --no-audit --no-fund
           npx --yes --package typescript tsc --noEmit --skipLibCheck triviumdb.d.ts
 
   # ═══════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- use npm install for release validation because package-lock.json is intentionally ignored
- preserve TypeScript declaration validation before publishing

## Validation
- npm install --no-audit --no-fund
- npx --yes --package typescript tsc --noEmit --skipLibCheck triviumdb.d.ts
- git diff --check