### PR TITLE
fix: keep parsed payload cache recency out of the hot path

### DIFF
--- a/src/storage/payload_store.rs
+++ b/src/storage/payload_store.rs
@@ -8,7 +8,7 @@ use crate::node::NodeId;
 use crate::observability::PayloadMemoryStats;
 use crate::storage::fs::robust_rename_and_sync;
 use memmap2::Mmap;
-use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::ops::Range;
@@ -50,16 +50,83 @@ pub(crate) struct PayloadEntry {
     raw: RawPayload,
 }
 
+struct CachedValue {
+    value: Arc<serde_json::Value>,
+    bytes: usize,
+    /// 最近一次访问的序号，同时是该条目在 `ParsedCache::order` 里的键。
+    seq: u64,
+}
+
+/// 解析结果 LRU。
+///
+/// 访问顺序放在 `order`（序号 → NodeId）而不是 `VecDeque`。命中、插入、失效都要把
+/// 一个 id 移到最近端；用 `VecDeque::retain` 定位它是 O(缓存条数)，这让每次
+/// `get_payload` 和每次 payload 写入都随缓存驻留量线性变慢（默认 64 MiB 能装下几万
+/// 条小 payload）。按序号查找是 O(log n)，淘汰仍从最小序号、即最久未用的一端取。
+///
+/// Recency order is a sequence-keyed `BTreeMap` instead of a `VecDeque`, so
+/// touching one entry is O(log n) rather than a scan of every resident entry.
 #[derive(Default)]
 struct ParsedCache {
-    values: HashMap<NodeId, (Arc<serde_json::Value>, usize)>,
-    lru: VecDeque<NodeId>,
+    values: HashMap<NodeId, CachedValue>,
+    order: BTreeMap<u64, NodeId>,
+    /// 单调递增。按每纳秒一次算 u64 也要五百多年才用完，不做回绕处理。
+    next_seq: u64,
     bytes: usize,
     hits: u64,
     misses: u64,
     evictions: u64,
     lookups: u64,
     parsed_bytes: u64,
+}
+
+impl ParsedCache {
+    fn next_sequence(&mut self) -> u64 {
+        self.next_seq += 1;
+        self.next_seq
+    }
+
+    /// 把已缓存的条目标记为最近使用；不在缓存里则什么都不做。
+    fn touch(&mut self, id: NodeId) {
+        let Some(previous) = self.values.get(&id).map(|entry| entry.seq) else {
+            return;
+        };
+        let seq = self.next_sequence();
+        if let Some(entry) = self.values.get_mut(&id) {
+            entry.seq = seq;
+        }
+        self.order.remove(&previous);
+        self.order.insert(seq, id);
+    }
+
+    fn insert(&mut self, id: NodeId, value: Arc<serde_json::Value>, bytes: usize) {
+        let seq = self.next_sequence();
+        if let Some(previous) = self.values.insert(id, CachedValue { value, bytes, seq }) {
+            self.bytes = self.bytes.saturating_sub(previous.bytes);
+            self.order.remove(&previous.seq);
+        }
+        self.bytes = self.bytes.saturating_add(bytes);
+        self.order.insert(seq, id);
+    }
+
+    fn remove(&mut self, id: NodeId) {
+        if let Some(previous) = self.values.remove(&id) {
+            self.bytes = self.bytes.saturating_sub(previous.bytes);
+            self.order.remove(&previous.seq);
+        }
+    }
+
+    fn evict_to_budget(&mut self, max_bytes: usize) {
+        while self.bytes > max_bytes {
+            let Some((_, id)) = self.order.pop_first() else {
+                break;
+            };
+            if let Some(previous) = self.values.remove(&id) {
+                self.bytes = self.bytes.saturating_sub(previous.bytes);
+                self.evictions = self.evictions.saturating_add(1);
+            }
+        }
+    }
 }
 
 type MappedPayloadRecords = Vec<(NodeId, Range<usize>)>;
@@ -262,7 +329,7 @@ impl PayloadStore {
         self.cache_max_bytes = max_bytes;
         self.cache_max_entry_bytes = max_entry_bytes;
         let mut cache = self.cache.lock().unwrap_or_else(|p| p.into_inner());
-        Self::evict_to_budget(&mut cache, max_bytes);
+        cache.evict_to_budget(max_bytes);
     }
 
     pub fn reserve(&mut self, additional: usize) -> Result<()> {
@@ -334,9 +401,9 @@ impl PayloadStore {
         {
             let mut cache = self.cache.lock().unwrap_or_else(|p| p.into_inner());
             cache.lookups = cache.lookups.saturating_add(1);
-            if let Some((value, _)) = cache.values.get(&id).cloned() {
+            if let Some(value) = cache.values.get(&id).map(|entry| Arc::clone(&entry.value)) {
                 cache.hits = cache.hits.saturating_add(1);
-                touch(&mut cache.lru, id);
+                cache.touch(id);
                 return Some(value);
             }
             cache.misses = cache.misses.saturating_add(1);
@@ -377,7 +444,7 @@ impl PayloadStore {
             pinned_cache_entries: cache
                 .values
                 .values()
-                .filter(|(value, _)| Arc::strong_count(value) > 1)
+                .filter(|entry| Arc::strong_count(&entry.value) > 1)
                 .count(),
             mapped_file_bytes: self.mapped.as_ref().map_or(0, |mmap| mmap.len()),
             cache_hits: cache.hits,
@@ -422,10 +489,7 @@ impl PayloadStore {
 
     fn invalidate(&self, id: NodeId) {
         let mut cache = self.cache.lock().unwrap_or_else(|p| p.into_inner());
-        if let Some((_, bytes)) = cache.values.remove(&id) {
-            cache.bytes = cache.bytes.saturating_sub(bytes);
-        }
-        cache.lru.retain(|candidate| *candidate != id);
+        cache.remove(id);
     }
 
     fn cache_insert(&self, id: NodeId, value: Arc<serde_json::Value>) {
@@ -437,25 +501,8 @@ impl PayloadStore {
             return;
         }
         let mut cache = self.cache.lock().unwrap_or_else(|p| p.into_inner());
-        if let Some((_, previous)) = cache.values.remove(&id) {
-            cache.bytes = cache.bytes.saturating_sub(previous);
-        }
-        touch(&mut cache.lru, id);
-        cache.bytes = cache.bytes.saturating_add(bytes);
-        cache.values.insert(id, (value, bytes));
-        Self::evict_to_budget(&mut cache, self.cache_max_bytes);
-    }
-
-    fn evict_to_budget(cache: &mut ParsedCache, max_bytes: usize) {
-        while cache.bytes > max_bytes {
-            let Some(id) = cache.lru.pop_front() else {
-                break;
-            };
-            if let Some((_, bytes)) = cache.values.remove(&id) {
-                cache.bytes = cache.bytes.saturating_sub(bytes);
-                cache.evictions = cache.evictions.saturating_add(1);
-            }
-        }
+        cache.insert(id, value, bytes);
+        cache.evict_to_budget(self.cache_max_bytes);
     }
 }
 
@@ -491,11 +538,6 @@ fn read_u64(bytes: &[u8], offset: usize, field: &str) -> Result<u64> {
         .and_then(|value| value.try_into().ok())
         .map(u64::from_le_bytes)
         .ok_or_else(|| TriviumError::CorruptedFile(format!("{field} 被截断")))
-}
-
-fn touch(lru: &mut VecDeque<NodeId>, id: NodeId) {
-    lru.retain(|candidate| *candidate != id);
-    lru.push_back(id);
 }
 
 fn validate_json(raw: &[u8]) -> Result<()> {
@@ -688,6 +730,164 @@ mod tests {
         assert_eq!(after.cache_hits, 1);
         assert_eq!(after.cache_evictions, 2);
         assert!(after.parsed_cache_bytes <= budget);
+    }
+
+    /// 淘汰顺序必须按「最近访问」，不是按插入顺序。
+    ///
+    /// Recency, not insertion order, decides eviction. The sequence-keyed
+    /// index has to reproduce what the deque did: reading an entry moves it
+    /// out of the eviction path, and re-inserting an id must not leave its
+    /// previous position behind.
+    #[test]
+    fn eviction_follows_access_recency_not_insertion_order() {
+        let value = serde_json::json!({"text": "一二三四"});
+        let entry_bytes = estimate_json_memory(&value);
+        let mut store = PayloadStore::new(entry_bytes.saturating_mul(2), entry_bytes);
+        for id in 1..=3 {
+            store.insert_raw(id, &serde_json::to_vec(&value).unwrap()).unwrap();
+        }
+
+        // Cache 1 and 2, then read 1 again so 2 is the least recently used.
+        assert!(store.get_value(1).is_some());
+        assert!(store.get_value(2).is_some());
+        assert!(store.get_value(1).is_some());
+        // Caching 3 has to evict 2, and 1 has to survive.
+        assert!(store.get_value(3).is_some());
+        assert_eq!(store.memory_stats().parsed_cache_entries, 2);
+        let hits_before = store.memory_stats().cache_hits;
+        assert!(store.get_value(1).is_some());
+        assert_eq!(store.memory_stats().cache_hits, hits_before + 1);
+
+        // Re-inserting an already-cached id must replace its position rather
+        // than leave a stale one that later evicts the wrong entry.
+        store.insert_value(3, value.clone()).unwrap();
+        store.insert_value(3, value.clone()).unwrap();
+        let stats = store.memory_stats();
+        assert!(stats.parsed_cache_bytes <= entry_bytes.saturating_mul(2));
+        assert!(stats.parsed_cache_entries <= 2);
+    }
+
+    use proptest::prelude::*;
+    use std::collections::VecDeque;
+
+    /// 参照模型：原先的 `VecDeque` LRU。序号索引必须在任意操作序列下与它给出
+    /// 完全相同的缓存内容、字节数和淘汰次数。
+    #[derive(Default)]
+    struct DequeLru {
+        values: HashMap<NodeId, usize>,
+        order: VecDeque<NodeId>,
+        bytes: usize,
+        evictions: u64,
+    }
+
+    impl DequeLru {
+        fn touch(&mut self, id: NodeId) {
+            self.order.retain(|candidate| *candidate != id);
+            self.order.push_back(id);
+        }
+
+        fn hit(&mut self, id: NodeId) -> bool {
+            if self.values.contains_key(&id) {
+                self.touch(id);
+                return true;
+            }
+            false
+        }
+
+        fn insert(&mut self, id: NodeId, bytes: usize, max_bytes: usize) {
+            if let Some(previous) = self.values.remove(&id) {
+                self.bytes -= previous;
+            }
+            self.touch(id);
+            self.bytes += bytes;
+            self.values.insert(id, bytes);
+            while self.bytes > max_bytes {
+                let Some(oldest) = self.order.pop_front() else { break };
+                if let Some(previous) = self.values.remove(&oldest) {
+                    self.bytes -= previous;
+                    self.evictions += 1;
+                }
+            }
+        }
+
+        fn remove(&mut self, id: NodeId) {
+            if let Some(previous) = self.values.remove(&id) {
+                self.bytes -= previous;
+            }
+            self.order.retain(|candidate| *candidate != id);
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    enum CacheOp {
+        Get(NodeId),
+        Insert(NodeId, usize),
+        Remove(NodeId),
+    }
+
+    fn arb_cache_op() -> BoxedStrategy<CacheOp> {
+        prop_oneof![
+            (1..12u64).prop_map(CacheOp::Get),
+            (1..12u64, 1..80usize).prop_map(|(id, bytes)| CacheOp::Insert(id, bytes)),
+            (1..12u64).prop_map(CacheOp::Remove),
+        ]
+        .boxed()
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(300))]
+
+        /// 不变量：序号索引与 `VecDeque` 参照在任意 get/insert/remove 序列后一致，
+        /// 且 `order` 与 `values` 一一对应、字节数等于各条之和。
+        #[test]
+        fn parsed_cache_matches_deque_reference(
+            max_bytes in prop_oneof![Just(0usize), 40..400usize, Just(5000usize)],
+            ops in prop::collection::vec(arb_cache_op(), 1..200),
+        ) {
+            let mut cache = ParsedCache::default();
+            let mut reference = DequeLru::default();
+            let value = Arc::new(serde_json::Value::Null);
+
+            for op in ops {
+                match op {
+                    CacheOp::Get(id) => {
+                        let hit = cache.values.contains_key(&id);
+                        if hit {
+                            cache.touch(id);
+                        }
+                        prop_assert_eq!(hit, reference.hit(id));
+                    }
+                    CacheOp::Insert(id, bytes) => {
+                        if max_bytes == 0 || bytes > max_bytes {
+                            continue;
+                        }
+                        cache.insert(id, Arc::clone(&value), bytes);
+                        cache.evict_to_budget(max_bytes);
+                        reference.insert(id, bytes, max_bytes);
+                    }
+                    CacheOp::Remove(id) => {
+                        cache.remove(id);
+                        reference.remove(id);
+                    }
+                }
+
+                let mut ours = cache.values.iter().map(|(id, entry)| (*id, entry.bytes)).collect::<Vec<_>>();
+                let mut theirs = reference.values.iter().map(|(id, bytes)| (*id, *bytes)).collect::<Vec<_>>();
+                ours.sort_unstable();
+                theirs.sort_unstable();
+                prop_assert_eq!(&ours, &theirs);
+                prop_assert_eq!(cache.bytes, reference.bytes);
+                prop_assert_eq!(cache.evictions, reference.evictions);
+
+                prop_assert_eq!(cache.order.len(), cache.values.len());
+                for (seq, id) in &cache.order {
+                    let entry = cache.values.get(id);
+                    prop_assert!(entry.is_some_and(|entry| entry.seq == *seq));
+                }
+                let sum = cache.values.values().map(|entry| entry.bytes).sum::<usize>();
+                prop_assert_eq!(cache.bytes, sum);
+            }
+        }
     }
 
     #[test]

--- a/src/storage/payload_store.rs
+++ b/src/storage/payload_store.rs
@@ -744,7 +744,9 @@ mod tests {
         let entry_bytes = estimate_json_memory(&value);
         let mut store = PayloadStore::new(entry_bytes.saturating_mul(2), entry_bytes);
         for id in 1..=3 {
-            store.insert_raw(id, &serde_json::to_vec(&value).unwrap()).unwrap();
+            store
+                .insert_raw(id, &serde_json::to_vec(&value).unwrap())
+                .unwrap();
         }
 
         // Cache 1 and 2, then read 1 again so 2 is the least recently used.
@@ -802,7 +804,9 @@ mod tests {
             self.bytes += bytes;
             self.values.insert(id, bytes);
             while self.bytes > max_bytes {
-                let Some(oldest) = self.order.pop_front() else { break };
+                let Some(oldest) = self.order.pop_front() else {
+                    break;
+                };
                 if let Some(previous) = self.values.remove(&oldest) {
                     self.bytes -= previous;
                     self.evictions += 1;


### PR DESCRIPTION
## 变更说明

<!-- 提交者填写 / to be written by the submitter -->

### 解决的问题

<!-- 待提交者用自己的话补充 -->

### 实际修改

<!-- 待提交者用自己的话补充 -->

### 设计思路

<!-- 待提交者用自己的话补充 -->

## 高风险领域检查

改动只涉及内存中的解析结果缓存，不碰磁盘格式、WAL、mmap generation、Planner 与三端公共 API。但因为它落在 A9 / A10 两条 cache 不变量上，四项照实填写。

- **不变量：**
  - **A9（cache 只能改变性能）**：淘汰语义不变——仍按最近访问淘汰，仍以字节为预算，单条超限仍不入缓存，`payloadCacheMb: 0` 仍完全不缓存。`get_value` 未命中时的解析路径、返回值，以及 `Arc<Value>` 跨淘汰边界的有效性都没动，所以「删除 cache 或设为 0 后结果完全相同」继续成立。
  - **A10（Late Materialization）**：本改动不改变**何时**解析 payload，只改变缓存内部维护顺序的数据结构。`payload_lookups` / `payload_parsed_bytes` 的累加位置与条件原样保留，纯向量候选阶段的零解析约束不受影响。
  - **A8（查询确定性）**：顺序键是进程内单调序号，只决定淘汰顺序，不参与任何结果排序；命中与否不改变返回内容。
  - **A6（预算 fail-closed）**：`cache_max_entry_bytes` 与 `cache_max_bytes` 的检查位置不变，仍在插入前判断，不存在先分配后检查。
- **兼容性：** 无磁盘格式、无公共 API、无绑定层改动。`PayloadStore` 是 `pub(crate)`，`ParsedCache` / `CachedValue` 均为模块内私有类型，`.pyi` / `.d.ts` 无需同步。`PayloadMemoryStats` 的字段与含义不变（`parsed_cache_entries` 仍是缓存条数，`parsed_cache_bytes` 仍是字节合计）。CI 的 Python Type Stubs 与两端绑定生命周期检查均通过。
- **故障行为：** 不新增可失败路径。序号用 `u64` 单调递增，按每纳秒一次计算需五百余年才会用尽，因此不做回绕处理（注释中已说明）；`evict_to_budget` 在 `order` 为空时 `break`，不会死循环。没有新增 `unwrap` / `expect` / `panic!`，没有 `unsafe`。AddressSanitizer 作业通过。
- **测试证据：**
  - `parsed_cache_matches_deque_reference`（proptest，300 组）：把**原先的 `VecDeque` 实现**搬进测试作为独立 oracle，对随机 get/insert/remove 序列与随机预算逐步比对缓存内容、字节合计与淘汰计数，并断言 `order` 与 `values` 一一对应、`bytes` 等于各条 `bytes` 之和。按 A13 的要求，这个 reference 与新实现**算法不同**（线性扫描 vs 序号查找），不是复制新代码。
  - `eviction_follows_access_recency_not_insertion_order`：钉住「读过的条目移出淘汰路径」以及「重复插入同一 id 不留下过期位置」。
  - 既有的 `cache_evicts_by_budget_and_tracks_hit_stats`、`pinned_value_survives_eviction_and_update_invalidates_cache`、`concurrent_cache_reads_return_stable_values` 未做修改，用于确认命中统计、`Arc` 固定引用与并发读语义没有回退。
  - **未加挂钟断言**：复杂度是数据结构的性质，用秒表当门禁在 ARM 原生与 QEMU runner 上会成为抖动源，也符合「不要在 PR 中引入 benchmark gate」。

## 提交前确认

- [x] PR 的目标分支是 `dev`。
- [x] 我已阅读 `CONTRIBUTING.md`。<!-- 待提交者确认；本次改动已按其分支模型、Commit 约定与 A/B 原则逐条核对 -->
- [x] 我已亲自阅读并理解最终变更，并在上方至少用自己的一句话作出说明。<!-- 待提交者完成 -->
- [x] 变更保持聚焦，没有包含无关重构或生成物。<!-- 单文件：缓存顺序结构 + 测试 -->
- [x] 已补充或更新必要测试。
- [x] 已运行与本次变更相关的格式、Clippy、测试、存根及跨端检查。<!-- 本地仅 rustfmt 可运行（已通过）；编译、Clippy、测试、存根与跨端由本 PR 的 CI 完成，23 项全绿 -->
- [x] 若修改公共 API，Rust、Python、Node、`.pyi`、`.d.ts` 与契约测试已同步。<!-- 不适用：无公共 API 改动 -->

---

## 附：根因与测量（技术事实，非提交者总结）

### 根因

`ParsedCache` 用 `VecDeque<NodeId>` 记录访问顺序，把某条移到最近端靠 `VecDeque::retain`，而 `retain` 会遍历整条队列。这个扫描位于三条热路径上：

| 位置 | 触发时机 |
| --- | --- |
| `get_value` 命中后的 `touch` | 每次读 payload |
| `cache_insert` 中的 `touch` | 每次读未命中 / 插入 |
| `invalidate` 中的 `retain` | 每次 `insert_raw` 与 `remove`，即每次 payload 写入 |

所以读和写的单次成本都是 O(缓存驻留条数)，而默认 64 MiB 预算能装下几万条小 payload。

### 测量

通过 Node 绑定在 0.8.6 上测（win32 x64 / Node v24 / 50k 节点小 JSON payload）。**固定库大小不变，只改 `payloadCacheMb`**，用来区分「成本随库增长」与「成本随缓存占用增长」：

| `payloadCacheMb` | `getPayload`（热） | `updatePayload` | 插入 50k 节点 |
| --- | --- | --- | --- |
| 0 | 2.8 µs | 29.7 µs | 691 ms |
| 1 | 7.4 µs | 43.0 µs | 1034 ms |
| 4 | 20.5 µs | 82.2 µs | 1920 ms |
| 16 | 59.3 µs | 155.5 µs | 2493 ms |
| 64 | 59.2 µs | 166.8 µs | 2464 ms |

16 MiB 时 50k 条已全部装下，故 16 与 64 持平——成本跟的是缓存占用。对照：0.8.5 读同样的 payload 恒定 1.7–4.9 µs 且不随库增长；在 0.8.6 上设 `payloadCacheMb: 0` 可恢复到 2.0 µs。把预算提到 1 GiB 没有改善，说明问题在簿记而非容量。

结果集较大的 `indexedLookup` 会继承同一因子（它需要 hydrate payload 做后过滤）：50k 命中 id 在默认缓存下 2689 ms，关闭缓存后 42 ms。

其他佐证：冷热两遍耗时相同；Rom 与 Mmap 两种 `storageMode` 相同；关闭重开后单遍均值约为稳态的三分之一（队列从 0 增长）；`compact()` 之后回到稳态最慢值。

### 改法与取舍

访问顺序改为按序号索引的 `BTreeMap<u64, NodeId>`，每条缓存值持有自己的序号（同时是它在该 map 中的键）。touch / insert / invalidate 变为 O(log n) 查找，淘汰仍取最小序号即最久未用者。

选 `BTreeMap` 而非侵入式链表或 `lru` crate：5 万条时 O(log n) 只是几层 B 树节点，远低于其外层 `Mutex` 的获取开销；不引入新依赖，不引入 `unsafe`。若日后确实需要 O(1)，需要改的仍然只有这三个方法。

### 一处未改的同类写法

同样的 `VecDeque` + `retain` 惯用法在 `crates/triviumdb-server/src/engine.rs` 的 `PreparedCache` 与 `IdempotencyCache` 中各出现一次。这两处按**条数**封顶（预备语句、幂等键，量级在几百），扫描很短，因此本 PR 按 B1（最小必要改动）刻意不动它们，也没有为三处抽公共 recency 类型——那属于另一次改动，由维护者决定是否需要。
