### PR TITLE
release: publish 0.8.8 FIND LIMIT hotfix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "triviumdb"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "aho-corasick",
  "bincode",
@@ -2491,7 +2491,7 @@ dependencies = [
 
 [[package]]
 name = "triviumdb-cli"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "triviumdb-server"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 
 [package]
 name = "triviumdb"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2024"
 authors = ["YoKONCy <2752026184@qq.com>"]
 description = "A high-performance memory-mmap hybrid search engine built for AI, combining dense vector, sparse text, graph relations, and JSON metadata."

--- a/crates/triviumdb-cli/Cargo.toml
+++ b/crates/triviumdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "triviumdb-cli"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2024"
 authors = ["YoKONCy <2752026184@qq.com>"]
 description = "CLI & TUI tool for TriviumDB — interactive REPL, non-interactive commands, and a full-screen terminal UI."

--- a/crates/triviumdb-server/Cargo.toml
+++ b/crates/triviumdb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "triviumdb-server"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2024"
 authors = ["YoKONCy <2752026184@qq.com>"]
 description = "HTTP server for TriviumDB"
@@ -22,7 +22,7 @@ tower = { version = "0.5", features = ["limit", "timeout", "util"] }
 tower-http = { version = "0.6", features = ["catch-panic", "limit", "request-id", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-triviumdb = { path = "../..", version = "0.8.7" }
+triviumdb = { path = "../..", version = "0.8.8" }
 uuid = { version = "1.18", features = ["v4"] }
 
 [dev-dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "triviumdb",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "AI-native embedded database: Vector + Graph + Relational in one file",
   "main": "index.js",
   "types": "triviumdb.d.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "triviumdb"
-version = "0.8.7"
+version = "0.8.8"
 description = "AI-native embedded database: Vector + Graph + Relational in one file"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/src/query/planner.rs
+++ b/src/query/planner.rs
@@ -131,8 +131,18 @@ pub fn plan_filter_with_limit<T: VectorType>(
         };
     }
     if let Some((field, op, inclusive, value)) = ordered_range(filter)
-        && let Some(candidates) =
-            mt.find_by_property_range(field, op, inclusive, &value, false, None)
+        && let Some(candidates) = mt.find_by_property_range(
+            field,
+            op,
+            inclusive,
+            &value,
+            false,
+            if is_single_ordered_range(filter) {
+                limit
+            } else {
+                None
+            },
+        )
     {
         return NodeAccessPlan {
             access_path: AccessPath::OrderedPropertyIndex {
@@ -143,7 +153,15 @@ pub fn plan_filter_with_limit<T: VectorType>(
             candidates,
         };
     }
-    plan_filter(filter, mt)
+    let plan = plan_filter(filter, mt);
+    if limit.is_some() && matches!(plan.access_path, AccessPath::ColdPayloadScan) {
+        return NodeAccessPlan {
+            access_path: AccessPath::FullNodeScan,
+            estimated_rows: plan.estimated_rows,
+            candidates: Vec::new(),
+        };
+    }
+    plan
 }
 
 pub fn plan_filter<T: VectorType>(filter: &Filter, mt: &MemTable<T>) -> NodeAccessPlan {
@@ -373,6 +391,13 @@ fn materialize_full_scan<T: VectorType>(plan: &mut NodeAccessPlan, mt: &MemTable
     if matches!(plan.access_path, AccessPath::FullNodeScan) && plan.candidates.is_empty() {
         plan.candidates = mt.all_node_ids();
     }
+}
+
+fn is_single_ordered_range(filter: &Filter) -> bool {
+    matches!(
+        filter,
+        Filter::Gt(..) | Filter::Gte(..) | Filter::Lt(..) | Filter::Lte(..) | Filter::Range(..)
+    )
 }
 
 fn ordered_range(filter: &Filter) -> Option<(&str, Ordering, bool, serde_json::Value)> {

--- a/tests/query/tql_planner.rs
+++ b/tests/query/tql_planner.rs
@@ -1,5 +1,8 @@
 use serde_json::json;
 use triviumdb::Database;
+use triviumdb::filter::{ComparableValue, Filter, RangeOp};
+use triviumdb::query::planner::{AccessPath, plan_filter_with_limit};
+use triviumdb::storage::memtable::MemTable;
 
 const DIM: usize = 4;
 
@@ -28,6 +31,7 @@ fn build(name: &str) -> (String, Database<f32>) {
             .insert(
                 &[sequence as f32, 0.0, 0.0, 0.0],
                 json!({
+                    "sequence": sequence,
                     "group": format!("group_{}", sequence % 10),
                     "rare": format!("rare_{sequence}"),
                     "side": if sequence == 199 { "target" } else { "source" },
@@ -188,6 +192,84 @@ fn planner_复合与_bitmap_访问路径和扫描结果一致() {
         r#"EXPLAIN FIND {$or: [{group: "group_1"}, {group: "group_3"}]} RETURN *"#,
     );
     assert_eq!(bitmap["access_path"]["kind"], "bitmap_property_index");
+
+    drop(db);
+    cleanup(&path);
+}
+
+#[test]
+fn planner_find_limit_保留安全提前停止且不截断残余过滤() {
+    let mut mt = MemTable::<f32>::new(DIM);
+    for sequence in 0..200usize {
+        mt.insert(
+            &[sequence as f32, 0.0, 0.0, 0.0],
+            json!({
+                "sequence": sequence,
+                "group": format!("group_{}", sequence % 10),
+                "side": if sequence == 199 { "target" } else { "source" },
+            }),
+        )
+        .unwrap();
+    }
+
+    let unindexed =
+        plan_filter_with_limit(&Filter::Eq("group".into(), json!("group_1")), Some(10), &mt);
+    assert!(matches!(unindexed.access_path, AccessPath::FullNodeScan));
+    assert!(unindexed.candidates.is_empty());
+
+    mt.register_ordered_property_index("sequence");
+    let range = Filter::Range(
+        "sequence".into(),
+        RangeOp::Gte,
+        ComparableValue::Number(0.into()),
+    );
+    let ordered = plan_filter_with_limit(&range, Some(10), &mt);
+    assert!(matches!(
+        ordered.access_path,
+        AccessPath::OrderedPropertyIndex { .. }
+    ));
+    assert_eq!(ordered.candidates.len(), 10);
+
+    let residual_filter = Filter::And(vec![range, Filter::Eq("side".into(), json!("target"))]);
+    let residual = plan_filter_with_limit(&residual_filter, Some(1), &mt);
+    assert!(matches!(
+        residual.access_path,
+        AccessPath::OrderedPropertyIndex { .. }
+    ));
+    assert_eq!(residual.candidates.len(), 200);
+    assert_eq!(
+        residual
+            .candidates
+            .iter()
+            .filter_map(|id| mt.get_payload(*id))
+            .filter(|payload| residual_filter.matches(payload))
+            .count(),
+        1
+    );
+
+    let (path, mut db) = build("find_limit_runtime");
+    let before = db.payload_memory_stats().payload_lookups;
+    let rows = db
+        .tql_nodes(r#"FIND {group: "group_1"} RETURN * LIMIT 10"#)
+        .unwrap();
+    let unindexed_lookups = db.payload_memory_stats().payload_lookups - before;
+    assert_eq!(rows.len(), 10);
+    assert!(unindexed_lookups < 200);
+
+    db.create_ordered_index("sequence").unwrap();
+    let before = db.payload_memory_stats().payload_lookups;
+    let rows = db
+        .tql_nodes("FIND {sequence: {$gte: 0}} RETURN * LIMIT 10")
+        .unwrap();
+    let ordered_lookups = db.payload_memory_stats().payload_lookups - before;
+    assert_eq!(rows.len(), 10);
+    assert!(ordered_lookups <= 11);
+
+    let rows = db
+        .tql_nodes(r#"FIND {sequence: {$gte: 0}, side: "target"} RETURN * LIMIT 1"#)
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["_"].payload["side"], "target");
 
     drop(db);
     cleanup(&path);

--- a/uv.lock
+++ b/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.9, <3.13"
 
 [[package]]
 name = "triviumdb"
-version = "0.8.7"
+version = "0.8.8"
 source = { editable = "." }


### PR DESCRIPTION
## Summary
- restore safe early stopping for unindexed FIND ... LIMIT queries
- restore bounded ordered-range candidates when the range fully covers the filter
- preserve complete candidate evaluation for residual predicates and the #49 composite-index fix
- publish the first post-0.8.7 hotfix as SemVer patch 0.8.8

## Validation
PR #55 passed the complete CI matrix, including ARM64 QEMU, ASan, coverage, fuzzing, Python bindings/stubs, and Node bindings/types.

## Release scope
Only package metadata changed to 0.8.8; documentation version text was intentionally left unchanged.

Fixes #54