### PR TITLE
feat(server): built-in Web Console served from / and /ui

### DIFF
--- a/crates/triviumdb-server/src/lib.rs
+++ b/crates/triviumdb-server/src/lib.rs
@@ -182,6 +182,9 @@ pub async fn build_app(config: ServerConfig) -> Result<Router, ApiError> {
     });
 
     Ok(Router::new()
+        .route("/", get(webui_index))
+        .route("/ui", get(webui_index))
+        .route("/ui/", get(webui_index))
         .route("/health/live", get(live))
         .route("/health/ready", get(ready))
         .route("/health/details", get(health_details))
@@ -217,6 +220,19 @@ pub async fn build_app(config: ServerConfig) -> Result<Router, ApiError> {
         .layer(DefaultBodyLimit::max(config.max_body_bytes))
         .layer(ServiceBuilder::new().layer(CatchPanicLayer::new()))
         .with_state(state))
+}
+
+const WEBUI_HTML: &str = include_str!("../web/index.html");
+
+async fn webui_index() -> impl IntoResponse {
+    (
+        [
+            (header::CONTENT_TYPE, "text/html; charset=utf-8"),
+            // 页面在编译期内嵌，升级 server 后必须让浏览器重新拉取，避免旧 UI 与新接口不匹配
+            (header::CACHE_CONTROL, "no-cache"),
+        ],
+        WEBUI_HTML,
+    )
 }
 
 async fn live() -> Json<HealthResponse> {

--- a/crates/triviumdb-server/tests/http_contract.rs
+++ b/crates/triviumdb-server/tests/http_contract.rs
@@ -1365,3 +1365,20 @@ async fn 请求体上限使用标准payload_too_large状态码() {
     assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     assert_eq!(json(response).await["code"], "PAYLOAD_TOO_LARGE");
 }
+
+#[tokio::test]
+async fn webui根路径与ui路由返回200及html页面() {
+    let (app, _directory) = app("webui").await;
+    let response = request(app.clone(), "GET", "/", None, &[]).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE).unwrap(),
+        "text/html; charset=utf-8"
+    );
+    let body = text(response).await;
+    assert!(body.contains("TriviumDB Web Console"));
+    assert!(body.contains("三模数据库可视化实战教程"));
+
+    let ui_response = request(app, "GET", "/ui", None, &[]).await;
+    assert_eq!(ui_response.status(), StatusCode::OK);
+}

--- a/crates/triviumdb-server/web/index.html
+++ b/crates/triviumdb-server/web/index.html
@@ -1,0 +1,5327 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>TriviumDB Web Console</title>
+  <style>
+    :root {
+      --bg-app: #f6f7f9;
+      --bg-surface: #ffffff;
+      --bg-surface-secondary: #f1f3f6;
+      --bg-inset: #eaeef3;
+      --border-color: #e5e9ef;
+      --border-strong: #d2d9e3;
+      --border-focus: #6366f1;
+      --text-main: #171c26;
+      --text-muted: #5b6572;
+      --text-light: #68737f;
+      --primary: #4f46e5;
+      --primary-hover: #4338ca;
+      --primary-bg: #eef2ff;
+      --accent: #0891b2;
+      --success: #059669;
+      --success-bg: #d6f5e7;
+      --warning: #b45309;
+      --warning-bg: #fdf0c9;
+      --danger: #dc2626;
+      --danger-bg: #fde3e3;
+      --tri-doc: #06b6d4;
+      --tri-graph: #f59e0b;
+      --tri-vector: #8b5cf6;
+      --font-mono: ui-monospace, "JetBrains Mono", "Fira Code", Consolas, Menlo, monospace;
+      --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      --sidebar-width: 264px;
+      --header-height: 52px;
+      --status-height: 28px;
+      --radius-sm: 6px;
+      --radius-md: 10px;
+      --radius-lg: 14px;
+      --shadow-sm: 0 1px 2px rgba(16, 24, 40, 0.05);
+      --shadow-md: 0 1px 3px rgba(16, 24, 40, 0.06), 0 6px 16px rgba(16, 24, 40, 0.07);
+      --shadow-lg: 0 12px 40px rgba(16, 24, 40, 0.18);
+    }
+
+    [data-theme="dark"] {
+      --bg-app: #0f1216;
+      --bg-surface: #151a20;
+      --bg-surface-secondary: #1c222a;
+      --bg-inset: #232a34;
+      --border-color: #242b35;
+      --border-strong: #333c49;
+      --border-focus: #818cf8;
+      --text-main: #e8ebf1;
+      --text-muted: #9aa4b2;
+      --text-light: #7e8998;
+      --primary: #818cf8;
+      --primary-hover: #a5b4fc;
+      --primary-bg: rgba(129, 140, 248, 0.14);
+      --accent: #22d3ee;
+      --success: #34d399;
+      --success-bg: rgba(16, 185, 129, 0.15);
+      --warning: #fbbf24;
+      --warning-bg: rgba(245, 158, 11, 0.15);
+      --danger: #f87171;
+      --danger-bg: rgba(239, 68, 68, 0.15);
+      --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+      --shadow-md: 0 1px 3px rgba(0, 0, 0, 0.35), 0 6px 16px rgba(0, 0, 0, 0.35);
+      --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.55);
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { height: 100%; }
+    body {
+      font-family: var(--font-sans);
+      background-color: var(--bg-app);
+      color: var(--text-main);
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+      overflow: hidden;
+      font-size: 13px;
+      -webkit-font-smoothing: antialiased;
+    }
+    ::selection { background: var(--primary-bg); }
+    :focus-visible { outline: 2px solid var(--border-focus); outline-offset: 1px; border-radius: 4px; }
+    ::-webkit-scrollbar { width: 10px; height: 10px; }
+    ::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 8px; border: 3px solid transparent; background-clip: content-box; }
+    ::-webkit-scrollbar-thumb:hover { background-color: var(--text-light); }
+    ::-webkit-scrollbar-track { background: transparent; }
+    code { font-family: var(--font-mono); font-size: 0.95em; }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        transition-duration: 0.01ms !important;
+        animation-duration: 0.01ms !important;
+      }
+    }
+
+    /* 顶部导航栏 */
+    header.app-header {
+      height: var(--header-height);
+      flex: none;
+      background: var(--bg-surface);
+      border-bottom: 1px solid var(--border-color);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 16px;
+      user-select: none;
+      z-index: 20;
+    }
+    .header-brand {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-weight: 650;
+      font-size: 14px;
+      letter-spacing: -0.01em;
+      color: var(--text-main);
+    }
+    .brand-mark { width: 24px; height: 24px; flex: none; }
+    .brand-dot { fill: var(--tri-doc); }
+    .brand-dot--graph { fill: var(--tri-graph); }
+    .brand-dot--vector { fill: var(--tri-vector); }
+    .brand-link { stroke: var(--border-strong); stroke-width: 1.4; stroke-linecap: round; }
+    .header-status {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    .status-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 3px 10px;
+      border-radius: 9999px;
+      font-size: 12px;
+      font-weight: 500;
+      background: var(--bg-surface-secondary);
+      color: var(--text-muted);
+      border: 1px solid var(--border-color);
+      transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    }
+    .status-badge.live { background: var(--success-bg); color: var(--success); border-color: transparent; }
+    .status-badge.dead { background: var(--danger-bg); color: var(--danger); border-color: transparent; }
+    .status-dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: currentColor;
+    }
+    .header-actions {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 5px 12px;
+      border-radius: var(--radius-sm);
+      font-size: 12px;
+      font-weight: 500;
+      font-family: inherit;
+      cursor: pointer;
+      border: 1px solid var(--border-color);
+      background: var(--bg-surface);
+      color: var(--text-main);
+      transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease, opacity 0.15s ease;
+      white-space: nowrap;
+    }
+    .btn:hover { background: var(--bg-surface-secondary); border-color: var(--border-strong); }
+    .btn:active { background: var(--bg-inset); }
+    /* <a> 复用 .btn 样式时去掉链接下划线 */
+    a.btn { text-decoration: none; }
+    .btn:disabled { opacity: 0.55; cursor: default; }
+    .btn svg { flex: none; }
+    .btn-primary {
+      background: var(--primary);
+      color: #ffffff;
+      border-color: var(--primary);
+    }
+    .btn-primary:hover {
+      background: var(--primary-hover);
+      border-color: var(--primary-hover);
+      color: #ffffff;
+    }
+    .btn-success { background: var(--success); color: #fff; border-color: var(--success); }
+    .btn-success:hover { opacity: 0.92; color: #fff; }
+
+    /* 主布局 */
+    .app-body {
+      flex: 1;
+      display: flex;
+      overflow: hidden;
+      position: relative;
+      min-height: 0;
+    }
+
+    /* 左侧对象导航树 */
+    aside.sidebar {
+      width: var(--sidebar-width);
+      flex: none;
+      background: var(--bg-surface);
+      border-right: 1px solid var(--border-color);
+      display: flex;
+      flex-direction: column;
+      user-select: none;
+      z-index: 10;
+    }
+    .sidebar-header {
+      padding: 12px 16px 10px;
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--text-light);
+      border-bottom: 1px solid var(--border-color);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .sidebar-content {
+      flex: 1;
+      overflow-y: auto;
+      padding: 8px 8px 12px;
+    }
+    .nav-section-title {
+      padding: 14px 8px 6px;
+      font-size: 10.5px;
+      font-weight: 600;
+      color: var(--text-light);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    .nav-item {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      padding: 6px 8px;
+      border-radius: var(--radius-sm);
+      cursor: pointer;
+      color: var(--text-main);
+      line-height: 1.4;
+      transition: background-color 0.12s ease, color 0.12s ease;
+    }
+    .nav-item:hover { background: var(--bg-surface-secondary); }
+    .nav-item.active {
+      background: var(--primary-bg);
+      color: var(--primary);
+      font-weight: 600;
+    }
+    .nav-item-left {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+    }
+    .nav-item-left > span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .nav-item-icon { width: 15px; height: 15px; flex: none; opacity: 0.8; }
+    .badge {
+      font-family: var(--font-mono);
+      font-size: 10px;
+      letter-spacing: 0.03em;
+      padding: 1px 7px;
+      border-radius: 9999px;
+      background: var(--bg-surface-secondary);
+      color: var(--text-muted);
+      border: none;
+      flex: none;
+    }
+    .nav-item.active .badge { background: transparent; color: inherit; }
+
+    /* 中央多标签页工作台 */
+    main.workspace {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      background: var(--bg-app);
+      min-width: 0;
+    }
+    .tabs-bar {
+      height: 40px;
+      flex: none;
+      background: var(--bg-surface);
+      border-bottom: 1px solid var(--border-color);
+      display: flex;
+      align-items: stretch;
+      padding: 0 12px;
+      gap: 4px;
+      overflow-x: auto;
+    }
+    .tab {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      padding: 0 12px;
+      cursor: pointer;
+      font-size: 12.5px;
+      font-weight: 500;
+      color: var(--text-muted);
+      border-bottom: 2px solid transparent;
+      margin-bottom: -1px;
+      user-select: none;
+      white-space: nowrap;
+      transition: color 0.15s ease, border-color 0.15s ease;
+    }
+    .tab:hover { color: var(--text-main); }
+    .tab.active {
+      color: var(--primary);
+      border-bottom-color: var(--primary);
+      font-weight: 600;
+    }
+
+    /* 工作区内容 */
+    .tab-pane {
+      display: none;
+      flex: 1;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .tab-pane.active { display: flex; }
+
+    /* 编辑器与工具栏 */
+    .editor-toolbar {
+      padding: 8px 12px;
+      background: var(--bg-surface);
+      border-bottom: 1px solid var(--border-color);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+    .toolbar-left, .toolbar-right {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .checkbox-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      cursor: pointer;
+      font-size: 12px;
+      color: var(--text-muted);
+      user-select: none;
+    }
+    .checkbox-label:hover { color: var(--text-main); }
+    .checkbox-label input { accent-color: var(--primary); }
+
+    /* 查询编辑器区域 (Split Pane) */
+    .query-layout {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .editor-container {
+      height: 180px;
+      min-height: 100px;
+      max-height: 60%;
+      background: var(--bg-surface);
+      border-bottom: 1px solid var(--border-color);
+      position: relative;
+      display: flex;
+      flex: none;
+    }
+    .editor-textarea {
+      flex: 1;
+      width: 100%;
+      height: 100%;
+      padding: 14px 64px 12px 16px;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      line-height: 1.6;
+      background: transparent;
+      color: var(--text-main);
+      border: none;
+      outline: none;
+      resize: none;
+      white-space: pre-wrap;
+      tab-size: 2;
+      caret-color: var(--primary);
+    }
+    .editor-chip {
+      position: absolute;
+      top: 10px;
+      right: 12px;
+      font-family: var(--font-mono);
+      font-size: 10px;
+      letter-spacing: 0.1em;
+      color: var(--text-light);
+      background: var(--bg-surface-secondary);
+      border: 1px solid var(--border-color);
+      border-radius: 4px;
+      padding: 2px 7px;
+      pointer-events: none;
+    }
+
+    /* 结果展示区 */
+    .results-container {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      background: var(--bg-surface);
+      min-height: 0;
+    }
+    .results-tabs {
+      height: 40px;
+      flex: none;
+      display: flex;
+      align-items: center;
+      padding: 0 12px;
+      gap: 2px;
+    }
+    .res-tab {
+      padding: 5px 10px;
+      border-radius: var(--radius-sm);
+      cursor: pointer;
+      font-size: 12px;
+      color: var(--text-muted);
+      border: none;
+      background: transparent;
+      user-select: none;
+      transition: background-color 0.12s ease, color 0.12s ease;
+    }
+    .res-tab:hover {
+      background: var(--bg-surface-secondary);
+      color: var(--text-main);
+    }
+    .res-tab.active {
+      background: var(--bg-inset);
+      color: var(--text-main);
+      font-weight: 600;
+    }
+    .res-content {
+      flex: 1;
+      overflow: auto;
+      position: relative;
+      min-height: 0;
+    }
+
+    /* 数据网格 (Data Grid) */
+    table.data-grid {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 12px;
+      text-align: left;
+    }
+    table.data-grid th {
+      position: sticky;
+      top: 0;
+      z-index: 2;
+      background: var(--bg-surface);
+      border-bottom: 1px solid var(--border-strong);
+      padding: 8px 12px;
+      font-weight: 600;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-muted);
+      cursor: pointer;
+      user-select: none;
+      white-space: nowrap;
+    }
+    table.data-grid th:hover { color: var(--text-main); }
+    table.data-grid td {
+      border-bottom: 1px solid var(--border-color);
+      padding: 7px 12px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 320px;
+      font-family: var(--font-mono);
+      font-size: 11.5px;
+    }
+    table.data-grid tbody tr { transition: background-color 0.1s ease; }
+    table.data-grid tbody tr:hover { background: var(--bg-surface-secondary); }
+    /* 虚拟滑窗（PR-12）：固定行高 + table-layout:fixed 显式列宽（首列 # 窄宽，其余均分）。
+       单元格单行省略与全局规则一致；行距以首窗渲染后实测为准，CSS 高度只是目标值。 */
+    table.data-grid.virtual-grid { table-layout: fixed; }
+    table.data-grid.virtual-grid th { overflow: hidden; text-overflow: ellipsis; }
+    table.data-grid.virtual-grid tbody tr:not(.virtual-spacer) { height: 32px; }
+    table.data-grid.virtual-grid tbody td { vertical-align: middle; }
+
+    /* Canvas 拓扑图 */
+    #graphCanvas {
+      width: 100%;
+      height: 100%;
+      display: block;
+      cursor: grab;
+    }
+    #graphCanvas:active { cursor: grabbing; }
+    .graph-controls {
+      position: absolute;
+      bottom: 16px;
+      right: 16px;
+      display: flex;
+      gap: 6px;
+      background: var(--bg-surface);
+      padding: 6px;
+      border-radius: var(--radius-md);
+      border: 1px solid var(--border-color);
+      box-shadow: var(--shadow-md);
+      z-index: 5;
+      flex-wrap: wrap;
+      max-width: calc(100% - 32px);
+    }
+    /* 图视图后端/着色切换按钮的激活态 */
+    .graph-controls .btn.active {
+      background: var(--primary);
+      border-color: var(--primary);
+      color: #ffffff;
+    }
+    /* Sigma WebGL 渲染容器：覆盖在 canvas 之上（canvas 后端时 hidden） */
+    .graph-sigma-container {
+      position: absolute;
+      inset: 0;
+      z-index: 2;
+      background: var(--bg-surface);
+    }
+    /* 社区着色图例（按社区模式显示） */
+    .graph-legend {
+      position: absolute;
+      top: 16px;
+      left: 16px;
+      z-index: 5;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px 12px;
+      max-width: 60%;
+      background: var(--bg-surface);
+      padding: 6px 10px;
+      border-radius: var(--radius-md);
+      border: 1px solid var(--border-color);
+      box-shadow: var(--shadow-md);
+      font-size: 11px;
+      color: var(--text-main);
+    }
+    .graph-legend .legend-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      white-space: nowrap;
+    }
+    .graph-legend .legend-swatch {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      flex: none;
+    }
+    .node-detail-drawer {
+      position: absolute;
+      top: 0;
+      right: 0;
+      width: 340px;
+      max-width: 85%;
+      height: 100%;
+      background: var(--bg-surface);
+      border-left: 1px solid var(--border-color);
+      box-shadow: var(--shadow-lg);
+      padding: 16px;
+      overflow-y: auto;
+      transform: translateX(calc(100% + 2px));
+      transition: transform 0.28s cubic-bezier(0.32, 0.72, 0, 1);
+      z-index: 10;
+    }
+    .node-detail-drawer.open { transform: translateX(0); }
+    .node-detail-drawer h4 { font-size: 13px; font-weight: 600; }
+
+    /* 节点 360° 视图 (Trinity 三平面) */
+    .inspector-plane { margin-bottom: 14px; }
+    .inspector-plane-title {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      font-size: 11.5px;
+      font-weight: 600;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin-bottom: 6px;
+    }
+    .inspector-dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      flex: none;
+    }
+    .inspector-vector { font-family: var(--font-mono); font-size: 11px; }
+    .inspector-vector-summary { color: var(--text-muted); margin-bottom: 6px; }
+    .inspector-vector-chip {
+      display: inline-block;
+      padding: 1px 6px;
+      margin: 0 3px 4px 0;
+      background: var(--bg-surface-secondary);
+      border: 1px solid var(--border-color);
+      border-radius: var(--radius-sm);
+      color: var(--text-main);
+    }
+    .inspector-edges { font-size: 12px; color: var(--text-muted); }
+    .inspector-edge-item {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 6px;
+      border-radius: var(--radius-sm);
+      margin-bottom: 3px;
+      background: var(--bg-surface-secondary);
+      font-family: var(--font-mono);
+      font-size: 11px;
+    }
+    .inspector-edge-label {
+      padding: 0 6px;
+      border: 1px solid var(--border-color);
+      border-radius: 9999px;
+      background: var(--bg-surface);
+      color: var(--tri-graph);
+      white-space: nowrap;
+    }
+    .inspector-edge-target {
+      cursor: pointer;
+      color: var(--primary);
+      background: none;
+      border: none;
+      padding: 0;
+      font: inherit;
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }
+    .inspector-edge-target:hover { color: var(--primary-hover); }
+    .inspector-edge-target:focus-visible { outline: 2px solid var(--border-focus); outline-offset: 1px; border-radius: 4px; }
+    .inspector-hint { font-size: 11px; color: var(--danger); background: var(--danger-bg); padding: 6px 8px; border-radius: var(--radius-sm); }
+
+    /* 可点击数据行（节点 360° 入口） */
+    table.data-grid tbody tr.row-clickable { cursor: pointer; }
+    table.data-grid tbody tr.row-clickable:hover { background: var(--bg-inset); }
+    table.data-grid tbody tr.row-clickable:focus-visible { outline: 2px solid var(--border-focus); outline-offset: -2px; }
+
+    /* 教程抽屉 (Interactive Tutorial Modal / Drawer) */
+    .tutorial-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(10, 13, 17, 0.45);
+      backdrop-filter: blur(4px);
+      -webkit-backdrop-filter: blur(4px);
+      z-index: 100;
+      display: none;
+      align-items: center;
+      justify-content: center;
+    }
+    .tutorial-overlay.open { display: flex; }
+    .tutorial-modal {
+      width: 800px;
+      max-width: 90vw;
+      height: 80vh;
+      background: var(--bg-surface);
+      border-radius: var(--radius-lg);
+      border: 1px solid var(--border-color);
+      box-shadow: var(--shadow-lg);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .tutorial-header {
+      padding: 14px 20px;
+      border-bottom: 1px solid var(--border-color);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .tutorial-body {
+      flex: 1;
+      display: flex;
+      overflow: hidden;
+    }
+    .tutorial-steps-nav {
+      width: 220px;
+      flex: none;
+      border-right: 1px solid var(--border-color);
+      background: var(--bg-surface);
+      overflow-y: auto;
+      padding: 8px;
+    }
+    .tutorial-step-item {
+      padding: 9px 12px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      border-radius: var(--radius-sm);
+      color: var(--text-muted);
+      font-size: 12.5px;
+      transition: background-color 0.12s ease, color 0.12s ease;
+    }
+    .tutorial-step-item:hover { background: var(--bg-surface-secondary); }
+    .tutorial-step-item.active {
+      background: var(--primary-bg);
+      color: var(--primary);
+      font-weight: 600;
+    }
+    .tutorial-content-pane {
+      flex: 1;
+      padding: 24px;
+      overflow-y: auto;
+      line-height: 1.65;
+      font-size: 13px;
+    }
+    .tutorial-content-pane h3 { font-size: 15px; margin-bottom: 8px; }
+    .tutorial-code-block {
+      background: var(--bg-app);
+      border: 1px solid var(--border-color);
+      border-radius: var(--radius-sm);
+      padding: 12px;
+      margin: 12px 0;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      line-height: 1.6;
+      position: relative;
+      white-space: pre-wrap;
+    }
+    .tutorial-content-pane .btn { margin-top: 4px; }
+
+    /* 轻提示 (Toast) */
+    .toast-stack {
+      position: fixed;
+      bottom: 40px;
+      left: 50%;
+      transform: translateX(-50%);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 8px;
+      z-index: 200;
+      pointer-events: none;
+    }
+    .toast {
+      padding: 8px 16px;
+      border-radius: 9999px;
+      background: var(--text-main);
+      color: var(--bg-surface);
+      font-size: 12.5px;
+      box-shadow: var(--shadow-lg);
+      opacity: 0;
+      transform: translateY(6px);
+      transition: opacity 0.2s ease, transform 0.2s ease;
+      max-width: 80vw;
+    }
+    .toast.show { opacity: 1; transform: translateY(0); }
+
+    /* 规模护栏提示条（图拓扑规模 / 查询行数上限共用；颜色全部走 CSS 变量，深浅主题自适应） */
+    .result-notice {
+      display: flex; align-items: center; gap: 10px;
+      margin: 0 0 8px; padding: 6px 8px 6px 12px;
+      border-radius: 8px;
+      background: var(--bg-surface);
+      border: 1px solid var(--border-color);
+      color: var(--text-main); font-size: 12.5px;
+      box-shadow: var(--shadow-md);
+      max-width: 100%;
+    }
+    .result-notice--floating {
+      position: absolute; top: 10px; left: 50%; transform: translateX(-50%);
+      margin: 0; z-index: 20; max-width: 90%;
+    }
+    .result-notice-close {
+      flex: none; margin-left: auto; padding: 1px 5px;
+      border: none; background: none; cursor: pointer;
+      color: var(--text-light); font-size: 13px; line-height: 1.2;
+      border-radius: 4px;
+    }
+    .result-notice-close:hover { color: var(--text-main); }
+    .result-notice-close:focus-visible { outline: 2px solid var(--border-focus); outline-offset: 1px; }
+    @media (prefers-reduced-motion: reduce) {
+      .result-notice { transition: none; }
+    }
+
+    /* 底部状态栏 */
+    footer.app-status-bar {
+      height: var(--status-height);
+      flex: none;
+      background: var(--bg-surface);
+      border-top: 1px solid var(--border-color);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0 14px;
+      font-family: var(--font-mono);
+      font-size: 11px;
+      color: var(--text-muted);
+      user-select: none;
+      z-index: 20;
+    }
+    .status-left, .status-right {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+    }
+    /* 状态栏语义色胶囊：QuIVer 预热 / 引擎就绪提示 */
+    .status-pill {
+      padding: 1px 8px;
+      border-radius: 9999px;
+      transition: background-color 0.2s ease, color 0.2s ease;
+    }
+    .status-pill--ok { background: var(--success-bg); color: var(--success); }
+    .status-pill--warn { background: var(--warning-bg); color: var(--warning); }
+    .status-pill--bad { background: var(--danger-bg); color: var(--danger); }
+
+    /* 向量检索实验台 (Vector Lab) */
+    .vector-lab { display: flex; flex: 1; overflow: hidden; }
+    .vl-config {
+      width: 340px;
+      flex: none;
+      overflow-y: auto;
+      padding: 14px;
+      border-right: 1px solid var(--border-color);
+      background: var(--bg-surface);
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    .vl-source-tabs { display: flex; gap: 6px; }
+    .vl-source-tab {
+      flex: 1;
+      padding: 6px 8px;
+      font-size: 12px;
+      font-family: inherit;
+      cursor: pointer;
+      border: 1px solid var(--border-color);
+      border-radius: var(--radius-sm);
+      background: var(--bg-surface);
+      color: var(--text-muted);
+      transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    }
+    .vl-source-tab:hover { color: var(--text-main); border-color: var(--border-strong); }
+    .vl-source-tab.active {
+      color: var(--primary);
+      border-color: var(--primary);
+      background: var(--bg-inset);
+      font-weight: 600;
+    }
+    .vl-source-body { display: flex; flex-direction: column; gap: 8px; }
+    .vl-label { font-size: 11px; color: var(--text-muted); }
+    .vl-input {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 6px 8px;
+      font-size: 12px;
+      font-family: var(--font-mono);
+      color: var(--text-main);
+      background: var(--bg-inset);
+      border: 1px solid var(--border-color);
+      border-radius: var(--radius-sm);
+    }
+    .vl-input:focus { border-color: var(--primary); outline: none; }
+    .vl-hint {
+      font-size: 11px;
+      color: var(--warning);
+      background: var(--warning-bg);
+      padding: 6px 8px;
+      border-radius: var(--radius-sm);
+      word-break: break-word;
+    }
+    .vl-hint--ok { color: var(--success); background: var(--success-bg); }
+    .vl-error {
+      font-size: 11.5px;
+      color: var(--danger);
+      background: var(--danger-bg);
+      padding: 8px 10px;
+      border-radius: var(--radius-sm);
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .vl-params { display: flex; gap: 10px; }
+    .vl-param {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 11px;
+      color: var(--text-muted);
+      font-family: var(--font-mono);
+    }
+    .vl-results {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      padding: 12px 14px;
+      gap: 10px;
+    }
+    .vl-pipeline {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+      font-size: 11.5px;
+      font-family: var(--font-mono);
+      color: var(--text-muted);
+    }
+    .vl-stage {
+      padding: 3px 10px;
+      border: 1px solid var(--border-color);
+      border-radius: 9999px;
+      background: var(--bg-surface-secondary);
+      color: var(--text-main);
+      white-space: nowrap;
+    }
+    .vl-stage b { color: var(--primary); }
+    .vl-arrow { color: var(--text-light); }
+    .vl-generation { margin-left: auto; font-size: 11px; color: var(--text-light); }
+
+    /* 通用空状态/加载器 */
+    .empty-placeholder {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      color: var(--text-light);
+      gap: 8px;
+    }
+    pre.json-view {
+      padding: 14px 16px;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      line-height: 1.6;
+      color: var(--text-main);
+      white-space: pre-wrap;
+    }
+
+    /* 可折叠 JSON 树（结果 JSON 视图 / 节点抽屉 Payload 平面 / mutation 结果共用） */
+    .json-tree { font-family: var(--font-mono); font-size: 12px; line-height: 1.6; }
+    .jt-line { display: flex; align-items: baseline; gap: 3px; min-height: 1.6em; flex-wrap: wrap; }
+    .jt-toggle {
+      flex: none; align-self: center; width: 15px; height: 16px; padding: 0;
+      border: none; background: none; color: var(--text-light); cursor: pointer;
+      font-family: var(--font-mono); font-size: 10px; line-height: 16px;
+      text-align: center; border-radius: 4px;
+    }
+    .jt-toggle:hover { color: var(--text-main); background: var(--bg-surface-secondary); }
+    .jt-toggle:focus-visible { outline: 2px solid var(--border-focus); outline-offset: 1px; }
+    .jt-key { color: var(--text-muted); }
+    .jt-badge {
+      flex: none; align-self: center; font-size: 10px; padding: 0 6px;
+      border-radius: 9999px; background: var(--bg-surface-secondary);
+      color: var(--text-light); border: 1px solid var(--border-color);
+    }
+    .jt-val-string { color: var(--success); }
+    .jt-val-number { color: var(--accent); }
+    .jt-val-bool { color: var(--warning); }
+    .jt-val-null { color: var(--text-light); font-style: italic; }
+    .jt-brace { color: var(--text-muted); }
+    .jt-children { margin-left: 8px; padding-left: 12px; border-left: 1px solid var(--border-color); }
+    .jt-children.collapsed { display: none; }
+    .jt-deep-marker {
+      flex: none; align-self: center; margin-left: 6px;
+      color: var(--text-light); font-style: italic; font-size: 10.5px;
+    }
+
+    /* 向量热力条（节点抽屉 Vector 平面 / 向量实验台预览共用） */
+    .heat-summary {
+      display: flex; align-items: center; gap: 8px; margin-bottom: 6px;
+      font-family: var(--font-mono); font-size: 11px; color: var(--text-muted);
+    }
+    .heat-strip {
+      display: flex; height: 14px; border-radius: 4px;
+      overflow: hidden; border: 1px solid var(--border-color);
+    }
+    .heat-strip i { flex: 1 1 0; min-width: 1px; }
+    .heat-strip i:hover { outline: 1px solid var(--text-main); outline-offset: -1px; }
+
+    /* 向量实验台 score 比例条 */
+    .score-cell { display: flex; align-items: center; gap: 8px; min-width: 150px; }
+    .score-bar { flex: 1; height: 6px; border-radius: 9999px; background: var(--bg-inset); overflow: hidden; }
+    .score-bar i { display: block; height: 100%; border-radius: 9999px; }
+
+    /* TQL 语法高亮叠加层（pre 与 textarea 必须完全对齐：同字体/行高/padding/white-space/tab-size/换行策略） */
+    .editor-highlight {
+      position: absolute; inset: 0; margin: 0; overflow: hidden;
+      padding: 14px 64px 12px 16px;
+      font-family: var(--font-mono); font-size: 13px; line-height: 1.6;
+      white-space: pre-wrap; overflow-wrap: break-word; word-break: normal; tab-size: 2;
+      color: var(--text-main); pointer-events: none;
+    }
+    .editor-textarea { position: relative; color: transparent; }
+    .editor-textarea::placeholder { color: var(--text-light); }
+    .editor-textarea::selection { background: rgba(99, 102, 241, 0.25); }
+    .tk-keyword { color: var(--primary); font-weight: 700; }
+    .tk-string { color: var(--warning); }
+    .tk-number { color: var(--accent); }
+    .tk-comment { color: var(--text-light); font-style: italic; }
+
+    /* 查询骨架屏（reduced-motion 下由全局规则退化为静态灰块） */
+    .sk-line {
+      height: 10px; border-radius: 4px;
+      background: linear-gradient(90deg, var(--bg-inset) 25%, var(--bg-surface-secondary) 45%, var(--bg-inset) 65%);
+      background-size: 300% 100%;
+      animation: sk-shimmer 1.2s ease infinite;
+    }
+    @keyframes sk-shimmer {
+      0% { background-position: 120% 50%; }
+      100% { background-position: -20% 50%; }
+    }
+
+    /* 结果区空态 CTA */
+    .empty-cta {
+      display: flex; flex-direction: column; align-items: center; gap: 10px;
+      padding: 34px 20px; color: var(--text-light);
+    }
+    .empty-cta svg { opacity: 0.55; }
+
+    /* 命令面板 (Ctrl/Cmd + K) */
+    .palette-overlay {
+      position: fixed; inset: 0; z-index: 300;
+      background: rgba(10, 13, 17, 0.45);
+      backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px);
+      display: none; align-items: flex-start; justify-content: center;
+      padding: 10vh 16px 16px;
+    }
+    .palette-overlay.open { display: flex; }
+    .palette {
+      width: 560px; max-width: 92vw; max-height: 62vh;
+      display: flex; flex-direction: column;
+      background: var(--bg-surface); border: 1px solid var(--border-color);
+      border-radius: var(--radius-lg); box-shadow: var(--shadow-lg);
+      overflow: hidden;
+    }
+    .palette-input {
+      flex: none; padding: 13px 16px; border: none; outline: none;
+      background: transparent; color: var(--text-main);
+      font-size: 14px; font-family: inherit;
+      border-bottom: 1px solid var(--border-color);
+    }
+    .palette-input::placeholder { color: var(--text-light); }
+    .palette-list { flex: 1; overflow-y: auto; padding: 6px; }
+    .palette-group {
+      padding: 8px 10px 4px; font-size: 10.5px; font-weight: 600;
+      text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-light);
+    }
+    .palette-item {
+      display: flex; align-items: center; gap: 10px;
+      padding: 8px 10px; border-radius: var(--radius-sm);
+      cursor: pointer; color: var(--text-main); font-size: 12.5px;
+    }
+    .palette-item:hover { background: var(--bg-surface-secondary); }
+    .palette-item.active { background: var(--primary-bg); color: var(--primary); }
+    .palette-item > span:first-child {
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
+    .palette-item mark { background: transparent; color: var(--primary); font-weight: 700; padding: 0; }
+    .palette-item.active mark { color: var(--primary-hover); }
+    .pi-kind {
+      margin-left: auto; flex: none; font-size: 10px;
+      color: var(--text-light); font-family: var(--font-mono);
+    }
+    .palette-empty { padding: 26px; text-align: center; color: var(--text-light); }
+    .palette-footer {
+      flex: none; display: flex; gap: 14px; padding: 8px 14px;
+      border-top: 1px solid var(--border-color);
+      font-size: 10.5px; color: var(--text-light); user-select: none;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- 顶部导航栏 -->
+  <header class="app-header">
+    <div class="header-brand">
+      <svg class="brand-mark" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path class="brand-link" d="M8.6 7.4 15.3 8.6M7.3 9.3l2.2 6.1M16.5 11.7l-5.1 4.4"/>
+        <circle class="brand-dot" cx="6" cy="6.5" r="3"/>
+        <circle class="brand-dot brand-dot--graph" cx="18" cy="9" r="3"/>
+        <circle class="brand-dot brand-dot--vector" cx="10.5" cy="18" r="3"/>
+      </svg>
+      <span>TriviumDB Console</span>
+      <span class="badge">SERVER</span>
+    </div>
+
+    <div class="header-status">
+      <span id="connStatus" class="status-badge">
+        <span class="status-dot"></span>
+        <span id="connText">连接检测中...</span>
+      </span>
+      <span class="badge" id="headerGeneration">Generation: -</span>
+    </div>
+
+    <div class="header-actions">
+      <button class="btn btn-primary" id="openTutorialBtn">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        可视化使用教程
+      </button>
+      <!-- 跳转官网文档（新窗口打开，rel=noopener 防止 window.opener 泄露） -->
+      <a class="btn" href="https://triviumdb.com/" target="_blank" rel="noopener" title="打开 TriviumDB 官方文档 (新窗口)">
+        文档 ↗
+      </a>
+      <button class="btn" id="themeToggleBtn" title="切换深色/浅色模式">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+      </button>
+    </div>
+  </header>
+
+  <!-- 主界面布局 -->
+  <div class="app-body">
+    <!-- 左侧对象导航树 (Navicat 风格对象管理器) -->
+    <aside class="sidebar">
+      <div class="sidebar-header">
+        <span>对象导航 (Explorer)</span>
+        <button class="btn" id="refreshMetaBtn" style="padding: 2px 6px;" title="刷新元数据">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M23 4v6h-6M1 20v-6h6"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
+        </button>
+      </div>
+      <div class="sidebar-content">
+        <div class="nav-section-title">三模数据引擎</div>
+        <div class="nav-item active" data-action="quick-find">
+          <div class="nav-item-left">
+            <svg class="nav-item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+            <span>文档 (Documents)</span>
+          </div>
+          <span class="badge" id="docCountBadge">FIND</span>
+        </div>
+        <div class="nav-item" data-action="quick-match">
+          <div class="nav-item-left">
+            <svg class="nav-item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+            <span>图拓扑 (Graph)</span>
+          </div>
+          <span class="badge">MATCH</span>
+        </div>
+        <div class="nav-item" data-action="quick-search">
+          <div class="nav-item-left">
+            <svg class="nav-item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>
+            <span>向量与 QuIVer</span>
+          </div>
+          <span class="badge">SEARCH</span>
+        </div>
+
+        <div class="nav-section-title">常用代码片段 (Snippets)</div>
+        <div class="nav-item" data-snippet='FIND {type: "person"} RETURN * LIMIT 20'>
+          <div class="nav-item-left">
+            <svg class="nav-item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.5" y2="16.5"/></svg>
+            <span>扫描所有节点</span>
+          </div>
+        </div>
+        <div class="nav-item" data-snippet="MATCH (a)-[]->(b) RETURN a, b LIMIT 25">
+          <div class="nav-item-left">
+            <svg class="nav-item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+            <span>探索一跳图关系</span>
+          </div>
+        </div>
+        <div class="nav-item" data-snippet="MATCH (a)-[:knows*1..3]->(b) RETURN a, b LIMIT 20">
+          <div class="nav-item-left">
+            <svg class="nav-item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="5" cy="6" r="3"/><circle cx="19" cy="18" r="3"/><path d="M12 3a9 9 0 0 1 9 9M12 21a9 9 0 0 1-9-9"/></svg>
+            <span>多跳可变长路径</span>
+          </div>
+        </div>
+        <div class="nav-item" data-snippet='CREATE ({name: "Alice", type: "user", level: 5})'>
+          <div class="nav-item-left">
+            <svg class="nav-item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+            <span>创建单节点 (Doc)</span>
+          </div>
+        </div>
+        <div class="nav-item" data-snippet='EXPLAIN ANALYZE FIND {type: "person"} RETURN *'>
+          <div class="nav-item-left">
+            <svg class="nav-item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+            <span>剖析执行计划</span>
+          </div>
+        </div>
+
+        <div class="nav-section-title">查询历史 (History)</div>
+        <div id="historyList" style="max-height: 160px; overflow-y: auto;">
+          <div style="padding: 6px 14px; color: var(--text-light); font-size: 11px;">暂无历史记录</div>
+        </div>
+      </div>
+    </aside>
+
+    <!-- 中央多标签页工作台 -->
+    <main class="workspace">
+      <!-- 标签栏 -->
+      <div class="tabs-bar">
+        <div class="tab active" data-tab="queryPane">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
+          <span>TQL 查询控制台</span>
+        </div>
+        <div class="tab" data-tab="graphExplorePane">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/></svg>
+          <span>独立图拓扑探索</span>
+        </div>
+        <div class="tab" data-tab="vectorLabPane">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="4" y1="20" x2="12" y2="12"/><line x1="12" y1="12" x2="20" y2="4"/><circle cx="4" cy="20" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="20" cy="4" r="2"/></svg>
+          <span>向量检索 (Vector Lab)</span>
+        </div>
+      </div>
+
+      <!-- 标签页 1：TQL 查询与结果控制台 -->
+      <div class="tab-pane active" id="queryPane">
+        <div class="editor-toolbar">
+          <div class="toolbar-left">
+            <button class="btn btn-success" id="runQueryBtn" title="运行查询 (快捷键: Ctrl + Enter)">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3"/></svg>
+              <span>运行 (Run)</span>
+            </button>
+            <label class="checkbox-label" title="开启写入事务支持 (CREATE / LINK / DELETE 等)">
+              <input type="checkbox" id="mutationCheck"> 写入模式 (Mutation)
+            </label>
+            <label class="checkbox-label" title="返回耗时剖析指标">
+              <input type="checkbox" id="profileCheck" checked> Profile 剖析
+            </label>
+          </div>
+          <div class="toolbar-right">
+            <button class="btn" id="formatTqlBtn" title="格式化查询文本">美化 TQL</button>
+            <button class="btn" id="clearEditorBtn" title="清空编辑器">清空</button>
+            <button class="btn" id="exportJsonBtn" title="导出当前结果为 JSON">导出 JSON</button>
+          </div>
+        </div>
+
+        <div class="query-layout">
+          <!-- 查询输入区（叠加层语法高亮：pre 与 textarea 文本对齐，textarea 文字透明仅露光标） -->
+          <div class="editor-container">
+            <pre class="editor-highlight" id="tqlHighlight" aria-hidden="true"></pre>
+            <textarea class="editor-textarea" id="tqlInput" spellcheck="false" placeholder="在此输入 TQL 语句，例如: FIND {type: &quot;person&quot;} RETURN * LIMIT 10 (按 Ctrl+Enter 运行)">FIND {type: "person"} RETURN * LIMIT 25</textarea>
+            <span class="editor-chip">TQL</span>
+          </div>
+
+          <!-- 结果展示区 -->
+          <div class="results-container">
+            <div class="results-tabs">
+              <div class="res-tab active" data-view="grid">
+                <span>表格网格 (Data Grid)</span>
+              </div>
+              <div class="res-tab" data-view="graph">
+                <span>交互拓扑图 (Graph Canvas)</span>
+              </div>
+              <div class="res-tab" data-view="json">
+                <span>JSON 原始树</span>
+              </div>
+            </div>
+
+            <div class="res-content">
+              <!-- 表格网格视图 -->
+              <div id="viewGrid" style="height: 100%; overflow: auto;">
+                <table class="data-grid" id="gridTable">
+                  <thead><tr id="gridHead"><th>#</th><th>数据</th></tr></thead>
+                  <tbody id="gridBody">
+                    <tr><td colspan="2">
+                      <div class="empty-cta">
+                        <svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.5" y2="16.5"/><line x1="11" y1="8" x2="11" y2="14"/><line x1="8" y1="11" x2="14" y2="11"/></svg>
+                        <div>还没有查询结果</div>
+                        <button class="btn btn-primary" id="emptyRunBtn" type="button">运行第一条查询</button>
+                      </div>
+                    </td></tr>
+                  </tbody>
+                </table>
+              </div>
+
+              <!-- 图拓扑画布视图 -->
+              <div id="viewGraph" style="display: none; width: 100%; height: 100%; position: relative;">
+                <canvas id="graphCanvas"></canvas>
+                <!-- Sigma WebGL 渲染容器（WebGL 后端启用时显示，覆盖 canvas） -->
+                <div class="graph-sigma-container" id="graphSigmaContainer" hidden></div>
+                <!-- 规模护栏提示条：节点数超过阈值时显示（可关闭，role=status） -->
+                <div class="result-notice result-notice--floating" id="graphScaleNotice" role="status" hidden>
+                  <span></span>
+                  <button class="result-notice-close" type="button" aria-label="关闭提示">✕</button>
+                </div>
+                <div class="graph-controls">
+                  <button class="btn" id="centerGraphBtn" title="重置居中">居中视角</button>
+                  <button class="btn" id="togglePhysicsBtn" title="固定物理模拟">冻结力学</button>
+                  <button class="btn" id="toggleWebGLBtn" title="切换 WebGL/Canvas 渲染后端（加载失败自动回退 Canvas）">WebGL 渲染</button>
+                  <button class="btn active" id="colorModeTypeBtn" title="按节点类型着色">按类型</button>
+                  <button class="btn" id="colorModeCommunityBtn" title="Louvain 社区检测着色（按需加载）">按社区</button>
+                </div>
+                <!-- 社区着色图例（按社区模式显示） -->
+                <div class="graph-legend" id="graphLegend" hidden></div>
+              </div>
+
+              <!-- JSON 树视图（可折叠 JSON 树渲染，导出功能不受影响） -->
+              <div id="viewJson" style="display: none; height: 100%; overflow: auto;">
+                <div class="json-view" id="rawJsonOutput"></div>
+              </div>
+
+              <!-- 节点 360° 详情抽屉（放在 res-content 层级，表格视图与图视图均可触发） -->
+              <div class="node-detail-drawer" id="nodeDrawer">
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
+                  <h4 id="drawerNodeTitle">节点详情</h4>
+                  <button class="btn" id="closeDrawerBtn" style="padding: 2px 6px;">✕</button>
+                </div>
+                <!-- Trinity 三平面：Payload / Vector / Edges -->
+                <section class="inspector-plane">
+                  <div class="inspector-plane-title"><span class="inspector-dot" style="background: var(--tri-doc);"></span>Payload</div>
+                  <div class="json-view" id="drawerNodePayload" style="padding: 8px 10px;"></div>
+                </section>
+                <section class="inspector-plane">
+                  <div class="inspector-plane-title"><span class="inspector-dot" style="background: var(--tri-vector);"></span>Vector</div>
+                  <div id="drawerNodeVector" class="inspector-vector"></div>
+                </section>
+                <section class="inspector-plane">
+                  <div class="inspector-plane-title"><span class="inspector-dot" style="background: var(--tri-graph);"></span>Edges</div>
+                  <div id="drawerNodeEdges" class="inspector-edges">-</div>
+                </section>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 标签页 2：独立图拓扑探索 -->
+      <div class="tab-pane" id="graphExplorePane">
+        <div class="editor-toolbar">
+          <div class="toolbar-left">
+            <button class="btn btn-primary" id="loadWholeGraphBtn">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/></svg>
+              加载全图拓扑 (Top 100 边)
+            </button>
+            <span style="color: var(--text-muted); font-size: 12px;">提示：可在画布上自由拖拽节点，滚轮缩放，单击节点查看属性</span>
+          </div>
+        </div>
+        <div style="flex: 1; position: relative; background: var(--bg-surface);">
+          <canvas id="standaloneGraphCanvas" style="width: 100%; height: 100%; display: block;"></canvas>
+          <!-- Sigma WebGL 渲染容器（独立画布的第二视图实例，共享同一图数据） -->
+          <div class="graph-sigma-container" id="standaloneSigmaContainer" hidden></div>
+          <div class="graph-controls">
+            <button class="btn" id="centerStandaloneBtn" title="重置居中">居中视角</button>
+            <button class="btn" id="toggleWebGLBtnStandalone" title="切换 WebGL/Canvas 渲染后端（加载失败自动回退 Canvas）">WebGL 渲染</button>
+            <button class="btn active" id="colorModeTypeBtnStandalone" title="按节点类型着色">按类型</button>
+            <button class="btn" id="colorModeCommunityBtnStandalone" title="Louvain 社区检测着色（按需加载）">按社区</button>
+          </div>
+          <div class="graph-legend" id="graphLegendStandalone" hidden></div>
+        </div>
+      </div>
+
+      <!-- 标签页 3：向量检索实验台 (Vector Lab) -->
+      <div class="tab-pane" id="vectorLabPane">
+        <div class="vector-lab">
+          <!-- 左侧：查询向量与参数配置 -->
+          <section class="vl-config">
+            <div class="vl-source-tabs">
+              <button class="vl-source-tab active" id="vlSourceTabNode" type="button">① 从节点选取</button>
+              <button class="vl-source-tab" id="vlSourceTabJson" type="button">② 粘贴 JSON</button>
+            </div>
+
+            <!-- 来源 1：节点选择器（主入口） -->
+            <div id="vlSourceNode" class="vl-source-body">
+              <label class="vl-label" for="vlSelectorQuery">候选节点筛选 TQL</label>
+              <input class="vl-input" id="vlSelectorQuery" value='FIND {type: "person"} RETURN * LIMIT 50' spellcheck="false">
+              <button class="btn btn-primary" id="vlLoadCandidatesBtn">加载候选节点</button>
+              <label class="vl-label" for="vlNodeSelect">选择节点（取其 vector 作为查询向量）</label>
+              <select class="vl-input" id="vlNodeSelect" size="6">
+                <option value="" disabled selected>先点击「加载候选节点」</option>
+              </select>
+              <div class="vl-hint" id="vlNodeHint" hidden></div>
+            </div>
+
+            <!-- 来源 2：JSON 粘贴 -->
+            <div id="vlSourceJson" class="vl-source-body" hidden>
+              <label class="vl-label" for="vlJsonInput">查询向量 JSON 数组</label>
+              <textarea class="vl-input" id="vlJsonInput" rows="4" spellcheck="false" placeholder="例如: [0.12, -0.45, 0.78, 0.33]"></textarea>
+              <div class="vl-hint vl-hint--ok" id="vlDimHint">维度校验：选中节点后以该节点 vector 维度为准，否则以服务端返回为准</div>
+              <div id="vlVectorPreview"></div>
+            </div>
+
+            <!-- 检索参数 -->
+            <div class="vl-params">
+              <label class="vl-param">top_k
+                <input class="vl-input" id="vlTopK" type="number" min="1" max="10000" value="10">
+              </label>
+              <label class="vl-param">min_score
+                <input class="vl-input" id="vlMinScore" type="number" step="0.05" value="-1">
+              </label>
+            </div>
+            <button class="btn btn-success" id="vlRunBtn">▶ 向量检索</button>
+          </section>
+
+          <!-- 右侧：检索结果 -->
+          <section class="vl-results">
+            <div class="vl-pipeline" id="vlPipeline" hidden>
+              <span class="vl-stage">召回 top_k <b id="vlPipelineTopK">-</b></span>
+              <span class="vl-arrow">→</span>
+              <span class="vl-stage">候选 rerank</span>
+              <span class="vl-arrow">→</span>
+              <span class="vl-stage">返回 hits <b id="vlPipelineHits">-</b></span>
+              <span class="vl-generation" id="vlGeneration"></span>
+            </div>
+            <div class="vl-error" id="vlSearchError" hidden></div>
+            <div style="flex: 1; overflow: auto;">
+              <table class="data-grid" id="vlResultTable" hidden>
+                <thead><tr><th>#</th><th>id</th><th>score</th><th>payload</th></tr></thead>
+                <tbody id="vlResultBody"></tbody>
+              </table>
+              <div class="empty-placeholder" id="vlEmpty">配置查询向量后点击「▶ 向量检索」</div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <!-- 底部状态与可观测性栏 -->
+  <footer class="app-status-bar">
+    <div class="status-left">
+      <span id="statusQueryTime">耗时: -</span>
+      <span id="statusRowCount">返回: 0 行</span>
+      <span id="statusAffected">影响: -</span>
+    </div>
+    <div class="status-right">
+      <span id="statusQuiver" class="status-pill" title="QuIVer 向量索引预热状态 (来自 /health/details 的 quiverWarmup)">QuIVer: -</span>
+      <span id="statusHealth" class="status-pill" title="引擎整体就绪状态 (来自 /health/details 的 status)"></span>
+      <span id="statusQueue">写队列: 0</span>
+      <span id="statusReads">并发读: 0</span>
+      <span id="statusVersion">TriviumDB Server v0.8.6</span>
+    </div>
+  </footer>
+
+  <!-- 命令面板 (Ctrl/Cmd + K 呼出) -->
+  <div class="palette-overlay" id="paletteOverlay">
+    <div class="palette" role="dialog" aria-modal="true" aria-label="命令面板">
+      <input class="palette-input" id="paletteInput" type="text" autocomplete="off" spellcheck="false"
+        placeholder="搜索命令、代码片段或查询历史… (↑↓ 选择，Enter 执行，Esc 关闭)"
+        aria-controls="paletteList" aria-activedescendant="" role="combobox" aria-expanded="true">
+      <div class="palette-list" id="paletteList" role="listbox" aria-label="命令列表"></div>
+      <div class="palette-footer" aria-hidden="true">
+        <span>↑↓ 选择</span><span>Enter 执行</span><span>Esc 关闭</span><span>Ctrl+K 呼出</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- 可视化交互教程弹窗 (Interactive Tutorial Modal) -->
+  <div class="tutorial-overlay" id="tutorialOverlay">
+    <div class="tutorial-modal">
+      <div class="tutorial-header">
+        <div style="display: flex; align-items: center; gap: 8px;">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--primary)" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg>
+          <strong style="font-size: 14px;">TriviumDB 三模数据库可视化实战教程</strong>
+        </div>
+        <button class="btn" id="closeTutorialBtn" style="padding: 2px 8px;">✕</button>
+      </div>
+      <div class="tutorial-body">
+        <div class="tutorial-steps-nav" id="tutorialStepsNav">
+          <!-- 教程步骤导航项由 JS 动态生成 -->
+        </div>
+        <div class="tutorial-content-pane" id="tutorialContentPane">
+          <!-- 教程正文由 JS 动态渲染 -->
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // ==========================================
+    // 全局状态与配置
+    // ==========================================
+    const API_BASE = window.location.origin.startsWith('http') ? window.location.origin : 'http://127.0.0.1:8080';
+    let currentGeneration = '-';
+    let queryHistory = JSON.parse(localStorage.getItem('tdb_query_history') || '[]');
+    let currentResultData = null;
+
+    // 力导向图模拟器状态
+    // 规模护栏：力导向为 O(n²) tick 循环，节点规模超阈值时逐级降级防主线程冻结
+    const GRAPH_PHYSICS_MAX_NODES = 300;   // 超过后自动关闭物理模拟（静态黄金角螺旋布局）
+    const GRAPH_RENDER_MAX_NODES = 1500;   // 超过后只渲染前 N 个节点（按返回顺序）
+    let physicsLockedByScale = false;      // 当前物理模拟是否因规模护栏被禁用（区别于用户手动冻结）
+    let graphTotalNodeCount = 0;           // 本次结果中的真实节点总数（截断渲染时用于提示文案）
+    let graphNodes = [];
+    let graphEdges = [];
+    let nodeMap = new Map();
+    let simulationRunning = true;
+    let simulationAlpha = 1;
+    let simulationRafId = null;
+    let selectedNode = null;
+    let transform = { x: 0, y: 0, k: 1 };
+    let isDraggingCanvas = false;
+    let dragStart = { x: 0, y: 0 };
+    let draggedNode = null;
+
+    // ==========================================
+    // 教程系统数据 (6 步体系化实战)
+    // ==========================================
+    const TUTORIAL_STEPS = [
+      {
+        id: "step1",
+        title: "1. 三模合一引擎总览",
+        badge: "核心架构",
+        desc: `<h3>🌟 为什么需要三模合一？</h3>
+        <p style="margin: 8px 0;">在构建现代 AI 与大模型应用时，通常需要搭建：<strong>向量数据库</strong>（做语义召回） + <strong>图数据库</strong>（做知识关联与多跳推导） + <strong>文档数据库</strong>（存业务 JSON 数据）。这带来了巨大的维护成本和数据同步延迟。</p>
+        <p style="margin: 8px 0;"><strong>TriviumDB</strong> 在单个存储引擎中把三者彻底融合：每一个节点天然具备 <code>NodeId</code>、<code>Payload (JSON 文档)</code>、<code>Vector (嵌入向量)</code> 以及任意方向的 <code>Edges (图关系)</code>！</p>
+        <div class="tutorial-code-block">
+          <strong>教学任务：一键写入示例知识图谱</strong><br>
+          点击下方按钮，将自动向本地服务器写入包含人员、论文与研究领域的测试三模数据！
+        </div>
+        <button class="btn btn-primary" onclick="initTutorialData()">⚡ 一键注入教学数据集</button>`
+      },
+      {
+        id: "step2",
+        title: "2. 文档过滤 (FIND 查询)",
+        badge: "文档模式",
+        desc: `<h3>📄 极简且强大的文档过滤</h3>
+        <p style="margin: 8px 0;">TriviumDB 支持原生 MongoDB 风格的丰富操作符，如 <code>$gte</code>、<code>$in</code>、<code>$regex</code> 等，且支持底层属性索引加速：</p>
+        <div class="tutorial-code-block">
+FIND {type: "person", citations: {$gte: 50}} RETURN *
+        </div>
+        <p>此查询将快速筛出引用量 ≥ 50 的人员节点，并在数据网格中呈现完整的 JSON Payload。</p>
+        <button class="btn btn-primary" onclick="runTutorialCode('FIND {type: &quot;person&quot;, citations: {$gte: 50}} RETURN *', false)">▶ 在工作台运行此查询</button>`
+      },
+      {
+        id: "step3",
+        title: "3. 图模式匹配 (MATCH)",
+        badge: "图模式",
+        desc: `<h3>🕸 关联发现与多跳关系匹配</h3>
+        <p style="margin: 8px 0;">使用熟悉的 Cypher 风格语法查询关联拓扑。例如找到 Alice 写过的论文及其涉及的领域：</p>
+        <div class="tutorial-code-block">
+MATCH (p {name: "Alice"})-[:AUTHORED]->(paper)-[:COVERS]->(topic)
+RETURN p, paper, topic
+        </div>
+        <p>执行后，切换至<strong>“交互拓扑图 (Graph Canvas)”</strong>，你可以直接用鼠标拖动节点，查看三模连接关系！</p>
+        <button class="btn btn-primary" onclick="runTutorialCode('MATCH (a)-[:AUTHORED]-&gt;(b)-[:COVERS]-&gt;(c) WHERE a.name == &quot;Alice&quot; RETURN a, b, c LIMIT 20', false, 'graph')">▶ 运行并查看图拓扑</button>`
+      },
+      {
+        id: "step4",
+        title: "4. 向量检索 (SEARCH VECTOR)",
+        badge: "向量模式",
+        desc: `<h3>🧬 极速向量近邻检索与 QuIVer 加速</h3>
+        <p style="margin: 8px 0;">TriviumDB 内置 QuIVer 向量索引与 BQ 编码加速，支持毫秒级 Top-K 召回：</p>
+        <div class="tutorial-code-block">
+SEARCH VECTOR [0.12, -0.45, 0.78, 0.33] TOP 3 RETURN *
+        </div>
+        <p>向量查询将直接按相似度排序返回最匹配的节点与得分。</p>
+        <button class="btn btn-primary" onclick="runTutorialCode('SEARCH VECTOR [0.12, -0.45, 0.78, 0.33] TOP 3 RETURN *', false)">▶ 运行向量检索</button>`
+      },
+      {
+        id: "step5",
+        title: "5. 自由 DIY 混合管线 (WITH)",
+        badge: "自由编排",
+        desc: `<h3>🔥 核心杀手锏：跨模混合管线</h3>
+        <p style="margin: 8px 0;">无需在应用程序端来回搬运数据！一条 TQL 即可将图匹配、属性过滤与向量检索自由串联：</p>
+        <div class="tutorial-code-block">
+MATCH (doc)-[:COVERS]->(t {name: "Tri-Model DB"})
+WHERE doc.year >= 2024
+RETURN doc, t
+        </div>
+        <button class="btn btn-primary" onclick="runTutorialCode('MATCH (doc)-[:COVERS]-&gt;(t {name: &quot;Tri-Model DB&quot;}) WHERE doc.year &gt;= 2024 RETURN doc, t', false, 'graph')">▶ 运行多模混合管线</button>`
+      },
+      {
+        id: "step6",
+        title: "6. OCC 乐观并发与事务",
+        badge: "企业级特性",
+        desc: `<h3>🛡 无锁高并发与 Generation ETag</h3>
+        <p style="margin: 8px 0;">TriviumDB Server 采用 <strong>Writer Actor + Group Commit + OCC (乐观并发控制)</strong> 架构：</p>
+        <ul style="margin-left: 20px; margin-bottom: 10px;">
+          <li>并发读绝不阻塞写，写操作通过有界队列由单一 Actor 动态合批提交；</li>
+          <li>通过全局 <code>Generation ETag</code> 校验版本冲突，确保高并发写入数据绝对一致。</li>
+        </ul>
+        <div class="tutorial-code-block">
+CREATE ({name: "Bob", type: "person", citations: 120, department: "AI Lab"})
+        </div>
+        <button class="btn btn-success" onclick="runTutorialCode('CREATE ({name: &quot;Bob&quot;, type: &quot;person&quot;, citations: 120, department: &quot;AI Lab&quot;})', true)">⚡ 体验一次安全的原子写入</button>`
+      }
+    ];
+
+    // ==========================================
+    // 初始化应用
+    // ==========================================
+    document.addEventListener('DOMContentLoaded', () => {
+      setupTheme();
+      setupEventListeners();
+      setupTutorial();
+      setupTabs();
+      setupVectorLab();
+      checkServerHealth();
+      renderHistory();
+      initCanvas('graphCanvas');
+      setupGraphRenderers();
+      setInterval(checkServerHealth, 5000);
+      setupPalette();
+      updateTqlHighlight();
+      // 应用初始化完成信号：供 scripts/ui-smoke.mjs 等自动化脚本等待，
+      // 避免在 DOMContentLoaded 监听器挂载前点击按钮导致竞态
+      window.__TRIVIUM_APP_READY = true;
+    });
+
+    // 主题切换（localStorage 优先；无保存值时跟随系统 prefers-color-scheme）
+    function setupTheme() {
+      const saved = localStorage.getItem('tdb_theme');
+      const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const initial = saved || (prefersDark ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', initial);
+      document.getElementById('themeToggleBtn').addEventListener('click', () => {
+        const current = document.documentElement.getAttribute('data-theme');
+        const next = current === 'dark' ? 'light' : 'dark';
+        document.documentElement.setAttribute('data-theme', next);
+        localStorage.setItem('tdb_theme', next);
+        redrawGraph();
+        // Sigma 实例的主题相关配色（节点边/画布底色）随主题重建
+        if (graphBackend === 'sigma') rebuildSigmaInstances();
+      });
+    }
+
+    // ==========================================
+    // 动效层（GSAP 可选加载，降级为无动画）
+    // ==========================================
+    const CANVAS_FONT_FAMILY = '-apple-system, "Segoe UI", sans-serif';
+
+    function initMotion() {
+      if (!window.gsap) return;
+      const mm = gsap.matchMedia();
+      mm.add({
+        reduce: '(prefers-reduced-motion: reduce)',
+        standard: '(prefers-reduced-motion: no-preference)'
+      }, (ctx) => {
+        if (ctx.conditions.reduce) return;
+        gsap.defaults({ ease: 'power3.out' });
+        gsap.timeline({ defaults: { duration: 0.5 } })
+          .from('header.app-header', { yPercent: -100, autoAlpha: 0 })
+          .from('aside.sidebar', { x: -20, autoAlpha: 0 }, '-=0.3')
+          .from('main.workspace', { y: 14, autoAlpha: 0 }, '-=0.35')
+          .from('footer.app-status-bar', { yPercent: 100, autoAlpha: 0 }, '-=0.3');
+        gsap.from('.brand-dot', {
+          scale: 0,
+          transformOrigin: '50% 50%',
+          stagger: 0.12,
+          duration: 0.45,
+          delay: 0.35,
+          ease: 'back.out(2.2)'
+        });
+        gsap.from('.sidebar-content .nav-item', {
+          x: -10,
+          autoAlpha: 0,
+          duration: 0.3,
+          stagger: 0.025,
+          delay: 0.25
+        });
+      });
+    }
+
+    function prefersReducedMotion() {
+      return window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    }
+
+    // 标签面板切换过渡：120ms fade + 4px 位移（GSAP 存在且未开启 reduced-motion 时生效，否则直接切换）
+    function animateTabIn(paneId) {
+      if (!window.gsap || prefersReducedMotion()) return;
+      const pane = document.getElementById(paneId);
+      if (!pane) return;
+      gsap.fromTo(pane,
+        { opacity: 0, y: 4 },
+        { opacity: 1, y: 0, duration: 0.12, ease: 'power1.out', overwrite: true, clearProps: 'opacity,transform' }
+      );
+    }
+
+    // 查询骨架屏：结果区 7 行 shimmer 占位，成功/失败后由渲染函数整体替换
+    function showSkeleton() {
+      const head = document.getElementById('gridHead');
+      const body = document.getElementById('gridBody');
+      head.innerHTML = '<th>#</th><th>执行中…</th>';
+      body.innerHTML = '';
+      const widths = [85, 58, 72, 40, 90, 52, 64];
+      widths.forEach((w, idx) => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td style="width: 40px;"><div class="sk-line" style="width: ${20 + (idx % 3) * 15}px;"></div></td>` +
+          `<td><div class="sk-line" style="width: ${w}%;"></div></td>`;
+        body.appendChild(tr);
+      });
+    }
+
+    function animateResultsIn() {
+      if (!window.gsap) return;
+      const target = document.getElementById('viewGrid');
+      if (!target || !target.offsetParent) return;
+      gsap.fromTo(target,
+        { opacity: 0 },
+        { opacity: 1, duration: 0.35, ease: 'power2.out', overwrite: true }
+      );
+    }
+
+    function showToast(message, duration = 2600) {
+      let stack = document.getElementById('toastStack');
+      if (!stack) {
+        stack = document.createElement('div');
+        stack.id = 'toastStack';
+        stack.className = 'toast-stack';
+        document.body.appendChild(stack);
+      }
+      const toast = document.createElement('div');
+      toast.className = 'toast';
+      toast.textContent = message;
+      stack.appendChild(toast);
+      requestAnimationFrame(() => toast.classList.add('show'));
+      setTimeout(() => {
+        toast.classList.remove('show');
+        setTimeout(() => toast.remove(), 250);
+      }, duration);
+    }
+
+    // 事件监听绑定
+    function setupEventListeners() {
+      // 网格行事件委托（tbody 一次性绑定；虚拟滑窗下严禁逐行绑定）
+      setupGridDelegation();
+      // 虚拟滑窗滚动驱动：scroll（passive）+ rAF 节流重算可视窗口；
+      // 粘底状态同步更新（不进 rAF，避免流式追加时判定滞后一帧）
+      document.getElementById('viewGrid').addEventListener('scroll', () => {
+        if (!gridVirtual) return;
+        gridVirtual.onScroll();
+        if (gridScrollRaf) return;
+        gridScrollRaf = requestAnimationFrame(() => {
+          gridScrollRaf = 0;
+          if (gridVirtual) gridVirtual.syncWindow();
+        });
+      }, { passive: true });
+      document.getElementById('runQueryBtn').addEventListener('click', executeCurrentQuery);
+      document.getElementById('clearEditorBtn').addEventListener('click', () => {
+        document.getElementById('tqlInput').value = '';
+        updateTqlHighlight();
+      });
+      document.getElementById('formatTqlBtn').addEventListener('click', formatTql);
+      document.getElementById('exportJsonBtn').addEventListener('click', exportJson);
+      document.getElementById('refreshMetaBtn').addEventListener('click', checkServerHealth);
+
+      // 语法高亮：输入同步渲染 + 滚动同步
+      const tqlArea = document.getElementById('tqlInput');
+      tqlArea.addEventListener('input', updateTqlHighlight);
+      tqlArea.addEventListener('scroll', () => {
+        const pre = document.getElementById('tqlHighlight');
+        pre.scrollTop = tqlArea.scrollTop;
+        pre.scrollLeft = tqlArea.scrollLeft;
+      });
+
+      // 空态 CTA（事件委托：初始空态与查询空结果共用）
+      document.addEventListener('click', (e) => {
+        if (e.target && e.target.id === 'emptyRunBtn') executeCurrentQuery();
+      });
+
+      // 图规模提示条关闭按钮（静态模板元素，无法在创建时绑定）
+      const graphNotice = document.getElementById('graphScaleNotice');
+      if (graphNotice) {
+        graphNotice.querySelector('.result-notice-close').addEventListener('click', () => {
+          graphNotice.hidden = true;
+        });
+      }
+
+      // 快捷键: Ctrl+Enter 运行
+      document.getElementById('tqlInput').addEventListener('keydown', (e) => {
+        if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+          e.preventDefault();
+          executeCurrentQuery();
+        }
+      });
+
+      // 快捷查询片段点击
+      document.querySelectorAll('[data-snippet]').forEach(el => {
+        el.addEventListener('click', () => {
+          setEditorValue(el.dataset.snippet);
+          if (el.dataset.snippet.startsWith('CREATE')) {
+            document.getElementById('mutationCheck').checked = true;
+          } else {
+            document.getElementById('mutationCheck').checked = false;
+          }
+          executeCurrentQuery();
+        });
+      });
+
+      // 快速动作
+      document.querySelectorAll('[data-action]').forEach(el => {
+        el.addEventListener('click', () => {
+          const action = el.dataset.action;
+          if (action === 'quick-find') {
+            setEditorValue('FIND {type: "person"} RETURN * LIMIT 25');
+            document.getElementById('mutationCheck').checked = false;
+          } else if (action === 'quick-match') {
+            setEditorValue('MATCH (a)-[]->(b) RETURN a, b LIMIT 25');
+            document.getElementById('mutationCheck').checked = false;
+          } else if (action === 'quick-search') {
+            setEditorValue('SEARCH VECTOR [0.1, 0.2, 0.3, 0.4] TOP 5 RETURN *');
+            document.getElementById('mutationCheck').checked = false;
+          }
+          executeCurrentQuery();
+        });
+      });
+    }
+
+    // 工作台标签页与结果视图切换
+    function setupTabs() {
+      document.querySelectorAll('.tabs-bar .tab').forEach(tab => {
+        tab.addEventListener('click', () => {
+          document.querySelectorAll('.tabs-bar .tab').forEach(t => t.classList.remove('active'));
+          document.querySelectorAll('.tab-pane').forEach(p => p.classList.remove('active'));
+          tab.classList.add('active');
+          const targetId = tab.dataset.tab;
+          document.getElementById(targetId).classList.add('active');
+          animateTabIn(targetId);
+          if (targetId === 'graphExplorePane') {
+            initStandaloneGraph();
+          }
+        });
+      });
+
+      document.querySelectorAll('.results-tabs .res-tab').forEach(tab => {
+        tab.addEventListener('click', () => {
+          document.querySelectorAll('.results-tabs .res-tab').forEach(t => t.classList.remove('active'));
+          tab.classList.add('active');
+          const view = tab.dataset.view;
+          document.getElementById('viewGrid').style.display = view === 'grid' ? 'block' : 'none';
+          document.getElementById('viewGraph').style.display = view === 'graph' ? 'block' : 'none';
+          document.getElementById('viewJson').style.display = view === 'json' ? 'block' : 'none';
+          if (view === 'graph') redrawGraph();
+        });
+      });
+    }
+
+    // ==========================================
+    // 后端 API 通信
+    // ==========================================
+    async function checkServerHealth() {
+      const connBadge = document.getElementById('connStatus');
+      const connText = document.getElementById('connText');
+      try {
+        const res = await fetch(`${API_BASE}/health/ready`);
+        if (res.ok) {
+          const data = await res.json();
+          connBadge.className = 'status-badge live';
+          connText.textContent = `在线 (${data.status})`;
+          document.getElementById('statusVersion').textContent = `TriviumDB Server v${data.version || '0.8.6'}`;
+        } else {
+          connBadge.className = 'status-badge dead';
+          connText.textContent = `就绪异常 (${res.status})`;
+        }
+      } catch (err) {
+        connBadge.className = 'status-badge dead';
+        connText.textContent = '无法连接 Server';
+      }
+
+      // 抓取详细指标
+      try {
+        const resDetails = await fetch(`${API_BASE}/health/details`);
+        if (resDetails.ok) {
+          const details = await resDetails.json();
+          document.getElementById('statusQueue').textContent = `写队列: ${details.writeQueueDepth || 0}/${details.writeQueueCapacity || 256}`;
+          document.getElementById('statusReads').textContent = `并发读: ${details.activeReads || 0}`;
+          renderStatusBarHealth(details);
+        }
+      } catch (_) {}
+    }
+
+    // 将 /health/details 的 quiverWarmup 与 status 渲染到底部状态栏
+    // quiverWarmup 可能取值: idle / preparing / building / ready / skipped / failed (与后端 WarmupState 对齐)
+    function renderStatusBarHealth(details) {
+      const quiverEl = document.getElementById('statusQuiver');
+      const healthEl = document.getElementById('statusHealth');
+
+      const quiverState = details.quiverWarmup || 'idle';
+      quiverEl.textContent = `QuIVer: ${quiverState}`;
+      quiverEl.className = 'status-pill ' + (
+        quiverState === 'ready' ? 'status-pill--ok' :
+        (quiverState === 'preparing' || quiverState === 'building') ? 'status-pill--warn' :
+        quiverState === 'failed' ? 'status-pill--bad' : ''
+      );
+
+      // 引擎整体状态非 ready 时给出可感知提示（正常时保持空白，避免与连接徽章重复）
+      if (details.status && details.status !== 'ready') {
+        healthEl.textContent = `引擎: ${details.status}`;
+        healthEl.className = 'status-pill status-pill--bad';
+        healthEl.title = `引擎整体状态异常: ${details.reason || details.status}`;
+      } else {
+        healthEl.textContent = '';
+        healthEl.className = 'status-pill';
+        healthEl.title = '引擎整体就绪状态 (来自 /health/details 的 status)';
+      }
+    }
+
+    // ==========================================
+    // 执行当前 TQL
+    // 只读查询携带 Accept: application/x-ndjson 走流式路径（PR-11）：
+    //   {"type":"meta"} → {"type":"row","row":{...}}* → {"type":"summary"}，
+    // 行级错误行 {"type":"error","detail":...} 不中断流，作为错误行内联显示。
+    // mutation 与 JSON 兜底（服务端 400/500 或老版本忽略 Accept）保持原 JSON 路径。
+    // ==========================================
+    const NDJSON_BATCH_SIZE = 200; // 流式渲染批次：缓冲满立即 flush，否则每帧一次（rAF）
+    let __lastTqlRequest = null;   // 自检观测点：最近一次 /v1/tql 请求头快照（mutation 是否携带 NDJSON Accept）
+
+    // 行级 JSON 解析：坏行不致命，转为 error 事件继续消费流
+    function parseNdjsonLine(line) {
+      try {
+        return JSON.parse(line);
+      } catch (e) {
+        return { type: 'error', detail: 'NDJSON 行解析失败: ' + e.message };
+      }
+    }
+
+    // 逐行消费 NDJSON 流：跨 chunk 残行缓冲，按 \n 切分，流末残余行兜底
+    async function consumeNdjsonStream(response, onEvent) {
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      const emitLine = (raw) => {
+        const line = raw.trim();
+        if (line) onEvent(parseNdjsonLine(line));
+      };
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        let nl;
+        while ((nl = buffer.indexOf('\n')) !== -1) {
+          emitLine(buffer.slice(0, nl));
+          buffer = buffer.slice(nl + 1);
+        }
+      }
+      buffer += decoder.decode();
+      emitLine(buffer);
+    }
+
+    // 流式网格增量渲染器：首行到达即建表头与首批行，之后逐批 append。
+    // NDJSON 流式下列集合无法预先得知：新列在流中动态出现时补 <th>。
+    // 行数达到虚拟阈值时从直建模式迁移到虚拟滑窗（保留滚动位置），
+    // 后续批次只更新数据数组 + 通知窗口重算（钉底跟随/视口保持由控制器处理）。
+    function createStreamGrid() {
+      const head = document.getElementById('gridHead');
+      const body = document.getElementById('gridBody');
+      const cols = ['#'];
+      const seen = new Set(cols);
+      const allRows = [];   // 流式累计数据（供事件委托解析行 + 虚拟迁移）
+      let rendered = 0;     // 已直建行数（迁移到虚拟后停增）
+      let virtual = null;   // 虚拟滑窗控制器（行数达阈值后接管渲染）
+      const grid = {
+        cols,
+        begin() {
+          teardownVirtualGrid();
+          head.innerHTML = '';
+          body.innerHTML = '';
+          cols.forEach(c => {
+            const th = document.createElement('th');
+            th.textContent = c;
+            head.appendChild(th);
+          });
+          gridDataRows = allRows;
+        },
+        ensureCols(row) {
+          Object.keys(row).forEach(k => {
+            if (seen.has(k)) return;
+            seen.add(k);
+            cols.push(k);
+            if (virtual) {
+              virtual.addCol(k);
+            } else {
+              const th = document.createElement('th');
+              th.textContent = k;
+              head.appendChild(th);
+            }
+          });
+        },
+        appendRows(batchRows) {
+          if (virtual) {
+            // 虚拟接管：只更新数据与窗口（spacer 总高/可视行随批次刷新）
+            batchRows.forEach(r => grid.ensureCols(r));
+            allRows.push(...batchRows);
+            virtual.notifyAppend();
+            return;
+          }
+          batchRows.forEach(r => grid.ensureCols(r));
+          const frag = document.createDocumentFragment();
+          batchRows.forEach(row => frag.appendChild(buildGridRow(row, rendered++, cols)));
+          body.appendChild(frag);
+          allRows.push(...batchRows);
+          // 达到虚拟阈值：从直建模式迁移到虚拟滑窗（保留滚动位置，后续批次走增量通知）
+          if (rendered >= VIRTUAL_GRID_MIN_ROWS) {
+            virtual = createVirtualGrid(allRows, cols, true);
+            gridVirtual = virtual;
+          }
+        },
+        appendErrorRow(detail) {
+          // 行级错误：textContent 渲染（XSS 安全），不中断流
+          const tr = document.createElement('tr');
+          const td = document.createElement('td');
+          td.colSpan = cols.length;
+          td.style.background = 'var(--danger-bg)';
+          td.style.color = 'var(--danger)';
+          td.style.padding = '10px 12px';
+          td.textContent = '⚠ 流式行错误: ' + detail;
+          tr.appendChild(td);
+          body.appendChild(tr);
+        }
+      };
+      return grid;
+    }
+
+    // NDJSON 流式消费与增量渲染：meta 更新 Generation；row 批量缓冲入网格；
+    // summary 终态收尾；结束后组装与 JSON 路径同形状的 currentResultData
+    // （导出 JSON / 图拓扑 / JSON 树视图共用，导出仍为全量行）
+    async function consumeNdjsonResult(response, query, startTime) {
+      const rows = [];
+      const streamErrors = [];
+      let generation = null;
+      let summary = null;
+      let grid = null;
+      let batch = [];
+      let flushScheduled = false;
+
+      const updateRowCount = () => {
+        document.getElementById('statusRowCount').textContent = `返回: ${rows.length} 行`;
+        // 10000 行上限提示改为基于流式累计行数（语义不变）
+        showRowLimitNotice(rows.length >= SERVER_MAX_QUERY_ROWS);
+      };
+      const flushBatch = () => {
+        flushScheduled = false;
+        if (!batch.length) return;
+        grid.appendRows(batch);
+        batch = [];
+        updateRowCount();
+      };
+      const scheduleFlush = () => {
+        if (flushScheduled) return;
+        flushScheduled = true;
+        requestAnimationFrame(flushBatch);
+      };
+
+      document.getElementById('statusAffected').textContent = '只读';
+
+      await consumeNdjsonStream(response, (evt) => {
+        if (!evt || typeof evt !== 'object' || !evt.type) return;
+        switch (evt.type) {
+          case 'meta':
+            generation = evt.generation || generation;
+            if (generation) {
+              currentGeneration = generation;
+              document.getElementById('headerGeneration').textContent = `Generation: ${generation}`;
+            }
+            break;
+          case 'row':
+            if (!grid) {
+              grid = createStreamGrid();
+              grid.begin();
+            }
+            rows.push(evt.row);
+            batch.push(evt.row);
+            if (batch.length >= NDJSON_BATCH_SIZE) flushBatch();
+            else scheduleFlush();
+            break;
+          case 'error':
+            streamErrors.push(evt.detail || String(evt));
+            if (!grid) {
+              grid = createStreamGrid();
+              grid.begin();
+            }
+            grid.appendErrorRow(evt.detail || '未知流式错误');
+            break;
+          case 'summary':
+            summary = evt;
+            break;
+          default:
+            break;
+        }
+      });
+
+      // 流结束收尾：冲掉残余批次（此后 rAF 里的迟到 flush 对空批次是 no-op）
+      flushBatch();
+
+      // 流完整性守卫：未收到 summary 行说明流被提前截断（网络中断/代理断连等），
+      // 记入 streamErrors 并内联提示，避免静默按部分结果落地
+      if (!summary) {
+        const detail = '流式响应提前结束（未收到 summary），结果可能不完整';
+        streamErrors.push(detail);
+        if (grid) grid.appendErrorRow(detail);
+      }
+
+      // 组装与 JSON 响应同形状的结果对象（rows 全量在内存，导出/视图行为一致）
+      currentResultData = Object.assign(
+        { rows, row_count: rows.length },
+        generation ? { generation } : {},
+        summary ? { rowCount: summary.rowCount, profile: summary.profile, indexAdvice: summary.indexAdvice } : {},
+        streamErrors.length ? { streamErrors } : {}
+      );
+      saveHistory(query);
+      updateRowCount();
+      document.getElementById('statusAffected').textContent = '只读';
+      document.getElementById('statusQueryTime').textContent = `耗时: ${(performance.now() - startTime).toFixed(1)} ms`;
+
+      if (!grid) {
+        // 空结果（仅 meta + summary rowCount 0）：与既有空态渲染保持一致
+        renderGrid([]);
+      }
+      renderGraph(rows);
+      renderRawJson(currentResultData);
+      animateResultsIn();
+    }
+
+    // JSON 结果统一落地（mutation 与流式兜底共用，行为与历史版本一致）
+    function applyJsonResult(data, isMutation, query) {
+      currentResultData = data;
+      saveHistory(query);
+      if (data.generation) {
+        currentGeneration = data.generation;
+        document.getElementById('headerGeneration').textContent = `Generation: ${data.generation}`;
+      }
+      if (isMutation) {
+        document.getElementById('statusAffected').textContent = `影响: ${data.affected || 0} 行`;
+        document.getElementById('statusRowCount').textContent = `创建: ${(data.createdIds || []).length} 个`;
+        renderMutationResult(data);
+      } else {
+        const rows = data.rows || [];
+        document.getElementById('statusRowCount').textContent = `返回: ${rows.length} 行`;
+        document.getElementById('statusAffected').textContent = '只读';
+        renderGrid(rows);
+        renderGraph(rows);
+        renderRawJson(data);
+      }
+    }
+
+    let __activeQueryCount = 0; // 未决查询计数：selftest runner 据此设置「排空屏障」，
+                                // 防止 fire-and-forget 查询的迟到渲染/落地跨测试边界污染断言
+
+    async function executeCurrentQuery() {
+      const query = document.getElementById('tqlInput').value.trim();
+      if (!query) return;
+
+      const isMutation = document.getElementById('mutationCheck').checked;
+      const isProfile = document.getElementById('profileCheck').checked;
+
+      const runBtn = document.getElementById('runQueryBtn');
+      __activeQueryCount++;
+      runBtn.disabled = true;
+      runBtn.innerHTML = `<span>执行中...</span>`;
+      showSkeleton();
+
+      const startTime = performance.now();
+      const requestHeaders = { 'Content-Type': 'application/json' };
+      // 只读查询声明可接受流式 NDJSON；mutation 不携带
+      // （服务端 mutation 恒返回 JSON，且避免向老版本服务器声明无法兑现的 Accept）
+      if (!isMutation) requestHeaders['Accept'] = 'application/x-ndjson';
+      __lastTqlRequest = { accept: requestHeaders['Accept'] || '', mutation: isMutation };
+
+      try {
+        const response = await fetch(`${API_BASE}/v1/tql`, {
+          method: 'POST',
+          headers: requestHeaders,
+          body: JSON.stringify({ query, mutation: isMutation, profile: isProfile })
+        });
+
+        const elapsed = (performance.now() - startTime).toFixed(1);
+        document.getElementById('statusQueryTime').textContent = `耗时: ${elapsed} ms`;
+
+        // 非 2xx：服务端错误（400/500）恒为 JSON 错误体，走既有渲染
+        if (!response.ok) {
+          const errorJson = await response.json().catch(() => ({ title: '未知错误', detail: response.statusText }));
+          renderError(errorJson);
+          return;
+        }
+
+        // 流式判定以响应 Content-Type 为准：老版本服务器忽略 Accept 返回 JSON 时自动兜底
+        const contentType = response.headers.get('Content-Type') || '';
+        const isNdjson = !isMutation && contentType.indexOf('application/x-ndjson') !== -1;
+
+        if (!isNdjson) {
+          const data = await response.json();
+          applyJsonResult(data, isMutation, query);
+          return;
+        }
+
+        await consumeNdjsonResult(response, query, startTime);
+      } catch (err) {
+        renderError({ title: '网络请求失败', detail: err.message });
+      } finally {
+        __activeQueryCount--;
+        runBtn.disabled = false;
+        runBtn.innerHTML = `<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3"/></svg><span>运行 (Run)</span>`;
+      }
+    }
+
+    // ==========================================
+    // 可折叠 JSON 树渲染（vanilla，无依赖）
+    // 类型着色：字符串绿 / 数字青 / 布尔橙 / null 灰 / 键 muted；
+    // 默认展开前 2 层，更深层折叠；对象/数组带计数徽标
+    // 深嵌套防护：子节点懒渲染（首次展开才构建 DOM），深度超阈值显示省略标记
+    // ==========================================
+    const JSON_TREE_MAX_DEPTH = 2;       // 默认展开深度
+    const JSON_TREE_EAGER_MAX = 200;     // 默认展开层的子节点直建上限（超出改懒渲染）
+    const JSON_TREE_MARKER_DEPTH = 20;   // 超过该深度的层级显示「… 更深 N 层」省略标记
+
+    // 有界子树深度测量：最多下探 cap 层、每层最多采样 50 个子节点（避免万行数组全量遍历）
+    function measureJsonDepth(value, cap) {
+      if (cap <= 0 || value === null || typeof value !== 'object') return 0;
+      const entries = Array.isArray(value) ? value.slice(0, 50) : Object.values(value).slice(0, 50);
+      let max = 0;
+      for (const v of entries) {
+        const d = measureJsonDepth(v, cap - 1);
+        if (d > max) max = d;
+      }
+      return max + 1;
+    }
+
+    function jtSpan(cls, text) {
+      const span = document.createElement('span');
+      span.className = cls;
+      span.textContent = text;
+      return span;
+    }
+
+    function jtPrimitive(value) {
+      if (value === null) return jtSpan('jt-val-null', 'null');
+      switch (typeof value) {
+        case 'string': return jtSpan('jt-val-string', JSON.stringify(value));
+        case 'number': return jtSpan('jt-val-number', String(value));
+        case 'boolean': return jtSpan('jt-val-bool', String(value));
+        default: return jtSpan('jt-val-null', String(value));
+      }
+    }
+
+    // 返回一个 wrapper（容器行 + 可折叠子层），key 为 null 表示根节点
+    function buildJsonTree(key, value, depth, needComma) {
+      const wrap = document.createElement('div');
+      const isObj = value !== null && typeof value === 'object';
+      const isArray = Array.isArray(value);
+      const keyPrefix = key === null ? '' : JSON.stringify(key) + ': ';
+
+      if (!isObj) {
+        const line = document.createElement('div');
+        line.className = 'jt-line';
+        if (key !== null) line.appendChild(jtSpan('jt-key', keyPrefix));
+        line.appendChild(jtPrimitive(value));
+        if (needComma) line.appendChild(jtSpan('jt-brace', ','));
+        wrap.appendChild(line);
+        return wrap;
+      }
+
+      const entries = isArray ? value.map((v, i) => [i, v]) : Object.entries(value);
+      const line = document.createElement('div');
+      line.className = 'jt-line';
+      wrap.appendChild(line);
+
+      // 空对象/数组内联展示，不生成折叠按钮
+      if (entries.length === 0) {
+        if (key !== null) line.appendChild(jtSpan('jt-key', keyPrefix));
+        line.appendChild(jtSpan('jt-brace', isArray ? '[]' : '{}'));
+        if (needComma) line.appendChild(jtSpan('jt-brace', ','));
+        return wrap;
+      }
+
+      const toggle = document.createElement('button');
+      toggle.type = 'button';
+      toggle.className = 'jt-toggle';
+      toggle.title = '折叠/展开';
+      line.appendChild(toggle);
+      if (key !== null) line.appendChild(jtSpan('jt-key', keyPrefix));
+      line.appendChild(jtSpan('jt-brace', isArray ? '[' : '{'));
+      line.appendChild(jtSpan('jt-badge', `${entries.length} ${isArray ? 'items' : 'keys'}`));
+      // 深嵌套省略标记：超过阈值深度的层级提示还有多少层（点击折叠按钮逐层展开）
+      if (depth >= JSON_TREE_MARKER_DEPTH) {
+        line.appendChild(jtSpan('jt-deep-marker', `… 更深 ${measureJsonDepth(value, 25)} 层`));
+      }
+
+      // 子层懒渲染：容器与闭合行先建，子节点首次展开时才构建（防深嵌套/大数组一次性全量建 DOM）
+      const children = document.createElement('div');
+      children.className = 'jt-children';
+      const closeLine = document.createElement('div');
+      closeLine.className = 'jt-line';
+      closeLine.appendChild(jtSpan('jt-brace', (isArray ? ']' : '}') + (needComma ? ',' : '')));
+      children.appendChild(closeLine);
+      wrap.appendChild(children);
+
+      let built = false;
+      const ensureChildren = () => {
+        if (built) return;
+        built = true;
+        entries.forEach(([k, v], idx) => {
+          children.insertBefore(buildJsonTree(k, v, depth + 1, idx < entries.length - 1), closeLine);
+        });
+      };
+
+      // 默认展开条件：深度在前 2 层内且子节点数不超过直建上限，否则初始折叠 + 懒渲染
+      const eager = depth < JSON_TREE_MAX_DEPTH && entries.length <= JSON_TREE_EAGER_MAX;
+      if (eager) ensureChildren();
+
+      const setCollapsed = (collapsed) => {
+        toggle.setAttribute('aria-expanded', String(!collapsed));
+        toggle.textContent = collapsed ? '▸' : '▾';
+        children.classList.toggle('collapsed', collapsed);
+      };
+      toggle.addEventListener('click', () => {
+        const willCollapse = toggle.getAttribute('aria-expanded') === 'true';
+        setCollapsed(willCollapse);
+        if (!willCollapse) ensureChildren();
+      });
+      setCollapsed(!eager);
+      return wrap;
+    }
+
+    function renderJsonTree(container, value) {
+      container.textContent = '';
+      container.classList.add('json-tree');
+      container.appendChild(buildJsonTree(null, value, 0, false));
+    }
+
+    // ==========================================
+    // 向量热力条（min-max 归一 → 顺序色带）
+    // ==========================================
+    // 顺序色带：深靛蓝(低) → indigo → cyan → 亮青(高)，双主题均可读
+    function heatColor(t) {
+      const stops = [
+        [30, 41, 89],
+        [79, 70, 229],
+        [6, 182, 212],
+        [165, 243, 252]
+      ];
+      const clamped = Math.min(Math.max(t, 0), 1);
+      const seg = Math.min(Math.floor(clamped * (stops.length - 1)), stops.length - 2);
+      const local = clamped * (stops.length - 1) - seg;
+      const a = stops[seg];
+      const b = stops[seg + 1];
+      const mix = a.map((v, i) => Math.round(v + (b[i] - v) * local));
+      return `rgb(${mix[0]}, ${mix[1]}, ${mix[2]})`;
+    }
+
+    function l2Norm(vector) {
+      return Math.sqrt(vector.reduce((acc, v) => acc + v * v, 0));
+    }
+
+    function renderHeatStrip(vector) {
+      const strip = document.createElement('div');
+      strip.className = 'heat-strip';
+      strip.setAttribute('role', 'img');
+      strip.setAttribute('aria-label', `向量热力条，共 ${vector.length} 维`);
+      let min = Infinity;
+      let max = -Infinity;
+      vector.forEach(v => { if (v < min) min = v; if (v > max) max = v; });
+      const range = max - min || 1;
+      vector.forEach((v, i) => {
+        const cell = document.createElement('i');
+        cell.style.background = heatColor((v - min) / range);
+        cell.title = `dim ${i}: ${Number(v).toFixed(4)}`;
+        strip.appendChild(cell);
+      });
+      return strip;
+    }
+
+    // 带摘要（dim + L2 范数）的热力条组合
+    function renderHeatBlock(vector, prefixLabel) {
+      const frag = document.createDocumentFragment();
+      const summary = document.createElement('div');
+      summary.className = 'heat-summary';
+      summary.textContent = `${prefixLabel ? prefixLabel + ' · ' : ''}dim = ${vector.length} · L2 = ${l2Norm(vector).toFixed(4)}`;
+      frag.appendChild(summary);
+      frag.appendChild(renderHeatStrip(vector));
+      return frag;
+    }
+
+    // ==========================================
+    // 视图渲染引擎
+    // ==========================================
+    // 服务端 max_query_rows=10000：结果达到该行数说明可能被截断，需提示
+    const SERVER_MAX_QUERY_ROWS = 10000;
+
+    // ==========================================
+    // 虚拟滑窗网格（PR-12）
+    // 数据全量在内存数组（gridDataRows），DOM 只构建可视窗口 ± 缓冲行：
+    //   - tbody 用 top/bottom 两个 spacer <tr> 撑出总滚动高度（height = 不可见行总高）
+    //   - scroll 事件（passive）+ rAF 节流驱动窗口重算，行池复用避免每帧 createElement
+    //   - 行高定值（CSS 目标 32px），首窗渲染后实测行距作为 spacer/窗口换算基准
+    //   - table-layout: fixed + colgroup 显式列宽（首列 # 固定窄宽，其余均分）
+    //   - 内容起始偏移（行数提示条 + sticky 表头）以 topSpacer 流内位置实测，避免换算漂移
+    // ==========================================
+    const VIRTUAL_GRID_MIN_ROWS = 200;  // 超过该行数启用虚拟滑窗（以下保持全量渲染路径）
+    const VIRTUAL_GRID_BUFFER = 5;      // 窗口上下缓冲行数
+    const GRID_ROW_HEIGHT = 32;         // 目标行高（实测行距失败时的兜底值）
+
+    let gridDataRows = null;  // 当前网格数据数组引用（事件委托据此解析行 → 节点抽屉）
+    let gridVirtual = null;   // 虚拟滑窗控制器（非虚拟模式为 null）
+    let gridScrollRaf = 0;    // 滚动 rAF 节流句柄
+
+    function teardownVirtualGrid() {
+      if (gridScrollRaf) { cancelAnimationFrame(gridScrollRaf); gridScrollRaf = 0; }
+      if (gridVirtual && gridVirtual.dispose) gridVirtual.dispose();
+      gridVirtual = null;
+      gridDataRows = null;
+      const table = document.getElementById('gridTable');
+      table.classList.remove('virtual-grid');
+      const cg = table.querySelector('colgroup');
+      if (cg) cg.remove();
+    }
+
+    // 行距实测：取前两行 rect top 差（border-collapse 下即行距）；单行/隐藏/异常时兜底
+    function measureGridRowPitch(body) {
+      const trs = body.querySelectorAll('tr:not(.virtual-spacer)');
+      if (trs.length >= 2) {
+        const pitch = trs[1].getBoundingClientRect().top - trs[0].getBoundingClientRect().top;
+        if (pitch > 0) return Math.round(pitch * 2) / 2;
+      }
+      if (trs.length === 1) {
+        const h = trs[0].getBoundingClientRect().height;
+        if (h > 0) return Math.round(h);
+      }
+      return GRID_ROW_HEIGHT;
+    }
+
+    function createVirtualGrid(rows, cols, preserveScroll) {
+      const container = document.getElementById('viewGrid');
+      const table = document.getElementById('gridTable');
+      const head = document.getElementById('gridHead');
+      const body = document.getElementById('gridBody');
+
+      table.classList.add('virtual-grid');
+      let colgroup = table.querySelector('colgroup');
+      if (!colgroup) {
+        colgroup = document.createElement('colgroup');
+        table.insertBefore(colgroup, table.firstChild);
+      }
+      // colgroup 显式列宽：首列 # 固定窄宽，其余列不设宽 → fixed 布局下均分剩余空间
+      colgroup.replaceChildren(...cols.map((c, i) => {
+        const col = document.createElement('col');
+        if (i === 0) col.style.width = '56px';
+        return col;
+      }));
+
+      head.innerHTML = '';
+      cols.forEach(c => {
+        const th = document.createElement('th');
+        th.textContent = c;
+        head.appendChild(th);
+      });
+
+      body.innerHTML = '';
+      const makeSpacer = () => {
+        const tr = document.createElement('tr');
+        tr.className = 'virtual-spacer';
+        const td = document.createElement('td');
+        td.colSpan = cols.length;
+        td.style.cssText = 'padding:0;border:none;line-height:0;';
+        tr.appendChild(td);
+        return tr;
+      };
+      const topSpacer = makeSpacer();
+      const bottomSpacer = makeSpacer();
+      body.appendChild(topSpacer);
+      body.appendChild(bottomSpacer);
+
+      let rowH = GRID_ROW_HEIGHT;
+      let winStart = -1;
+      let winEnd = -1;
+      let disposed = false;
+      let colsVersion = 0;
+      let pinnedBottom = false; // 粘底状态：流式追加时据此决定是否跟随滚动
+      const pool = [];
+      const renderedIdx = new Map(); // dataIndex -> tr
+
+      const setSpacer = (tr, px) => { tr.firstChild.style.height = px + 'px'; };
+      // 粘底判定：scrollTop+clientH 距内容底部不足 2 行。注意必须在 spacer 更新后
+      // 读取（scrollHeight 随 spacer 变化），流式追加的判定走 sticky 状态而非临时计算
+      const isAtBottom = () => container.scrollTop + container.clientHeight >= container.scrollHeight - rowH * 2;
+      // 内容起始偏移（行数提示条高度 + sticky 表头）：topSpacer 是 tbody 首行，
+      // 其流内位置不受自身/底部 spacer 高度影响，实测可避免 sticky 场景下的换算漂移
+      const contentTop = () => topSpacer.getBoundingClientRect().top
+        - container.getBoundingClientRect().top + container.scrollTop;
+
+      // 行池复用：优先复用既有 tr 就地更新（文本写入），仅对换列/换索引的行重新 patch
+      function patchRow(tr, row, idx) {
+        tr.dataset.rowIndex = String(idx);
+        const node = findNodeInRow(row);
+        tr.classList.toggle('row-clickable', !!node);
+        if (node) {
+          tr.tabIndex = 0;
+          tr.setAttribute('role', 'button');
+          tr.title = '点击查看该节点的 360° 视图 (Payload / Vector / Edges)';
+        } else {
+          tr.removeAttribute('tabindex');
+          tr.removeAttribute('role');
+          tr.removeAttribute('title');
+        }
+        if (tr.children.length !== cols.length) {
+          tr.replaceChildren(...cols.map(() => document.createElement('td')));
+        }
+        cols.forEach((c, i) => {
+          const td = tr.children[i];
+          if (c === '#') {
+            td.textContent = idx + 1;
+            td.style.color = 'var(--text-light)';
+          } else {
+            const val = row[c];
+            if (val === undefined || val === null) {
+              td.textContent = 'null';
+              td.style.color = 'var(--text-light)';
+            } else {
+              td.textContent = typeof val === 'object' ? JSON.stringify(val) : String(val);
+              td.style.color = '';
+            }
+          }
+        });
+      }
+
+      function syncWindow() {
+        if (disposed || !rows.length) return;
+        const total = rows.length;
+        const cTop = contentTop();
+        const firstVisible = Math.max(0, Math.floor((container.scrollTop - cTop) / rowH));
+        const start = Math.max(0, firstVisible - VIRTUAL_GRID_BUFFER);
+        const end = Math.min(total, firstVisible + Math.ceil(container.clientHeight / rowH) + VIRTUAL_GRID_BUFFER + 1);
+        if (start === winStart && end === winEnd) {
+          // 窗口未变但数据总量可能已增长（流式追加、视口停在原位）：
+          // bottom spacer 依赖 total，必须随 total 刷新，否则可滚动范围固化在迁移时刻
+          setSpacer(bottomSpacer, (total - end) * rowH);
+          return;
+        }
+        for (const [idx, tr] of Array.from(renderedIdx)) {
+          if (idx < start || idx >= end) {
+            renderedIdx.delete(idx);
+            pool.push(tr);
+            // 必须从 DOM 移除：孤儿行会累积抬高内容高度，破坏 spacer 换算与贴底判定
+            tr.remove();
+          }
+        }
+        for (let i = start; i < end; i++) {
+          let tr = renderedIdx.get(i);
+          if (!tr) {
+            tr = pool.pop() || document.createElement('tr');
+            renderedIdx.set(i, tr);
+          }
+          if (tr.dataset.colsVersion !== String(colsVersion) || Number(tr.dataset.rowIndex) !== i) {
+            patchRow(tr, rows[i], i);
+            tr.dataset.colsVersion = String(colsVersion);
+          }
+          body.insertBefore(tr, bottomSpacer);
+        }
+        setSpacer(topSpacer, start * rowH);
+        setSpacer(bottomSpacer, (total - end) * rowH);
+        winStart = start;
+        winEnd = end;
+        pinnedBottom = isAtBottom();
+      }
+
+      // 首窗：以兜底行高换算并渲染，再实测行距重算一次（spacer 换算随之校准）
+      if (!preserveScroll) container.scrollTop = 0;
+      syncWindow();
+      rowH = measureGridRowPitch(body);
+      syncWindow();
+
+      const api = {
+        rowH: () => rowH,
+        contentTop,
+        syncWindow,
+        dispose() { disposed = true; },
+        addCol(key) {
+          cols.push(key);
+          colsVersion++;
+          const th = document.createElement('th');
+          th.textContent = key;
+          head.appendChild(th);
+          colgroup.appendChild(document.createElement('col'));
+        },
+        // 滚动事件入口：同步更新粘底状态（rAF 窗口重算另行节流）。
+        // 必须同步：流式追加可能在下一次 rAF 前发生，粘底判定不能滞后一帧
+        onScroll() { pinnedBottom = isAtBottom(); },
+        // 流式追加：数据增长后重算 spacer 与窗口；粘底时跟随，否则保持视口。
+        // 判定 = sticky 状态 || 同步兜底计算：scroll 事件是异步任务，「钉底 → 立即追加」
+        // 时 pinnedBottom 可能尚未经 onScroll 更新；而后续批次 scrollHeight 已随
+        // spacer 变化，纯临时计算会因基准漂移误判「不在底部」而中断跟随 —— 两者取或
+        notifyAppend() {
+          const wasPinned = pinnedBottom || isAtBottom();
+          syncWindow();
+          if (wasPinned) {
+            // 贴底三步：先按新数据重算 spacer，再用新鲜布局精确钳到最大滚动位
+            // （scrollTop = scrollHeight 会按赋值瞬间的布局快照钳位，spacer/窗口
+            // 重排后高度基准变化会累积偏差），最后按新滚动位对齐可视窗口
+            syncWindow();
+            container.scrollTop = container.scrollHeight - container.clientHeight;
+            syncWindow();
+          }
+        }
+      };
+      return api;
+    }
+
+    // 键盘焦点移动：目标行滚入视口（必要时同步重算窗口，绕过 rAF 保证焦点立即落位）
+    function focusGridRow(idx) {
+      if (gridVirtual) {
+        const container = document.getElementById('viewGrid');
+        const rowH = gridVirtual.rowH();
+        const y = gridVirtual.contentTop() + idx * rowH;
+        if (y < container.scrollTop) {
+          container.scrollTop = y;
+        } else if (y + rowH > container.scrollTop + container.clientHeight) {
+          container.scrollTop = y + rowH - container.clientHeight;
+        }
+        gridVirtual.syncWindow();
+      }
+      const tr = document.querySelector(`#gridBody tr[data-row-index="${idx}"]`);
+      if (tr) tr.focus();
+    }
+
+    // 网格行事件委托（tbody 一次性绑定，虚拟/非虚拟路径共用；不得逐行绑定）：
+    // 点击/回车/空格打开节点 360° 抽屉；上下箭头在数据行间移动焦点并滚动跟随
+    function setupGridDelegation() {
+      const body = document.getElementById('gridBody');
+      const openRowDrawer = (tr) => {
+        const idx = Number(tr.dataset.rowIndex);
+        const row = gridDataRows ? gridDataRows[idx] : null;
+        if (row === undefined || row === null) return;
+        const node = findNodeInRow(row);
+        if (!node) return;
+        openNodeDrawer({
+          id: node.id,
+          label: node.payload?.name || node.payload?.title || `Node ${node.id}`,
+          payload: node.payload || {},
+          vector: node.vector || []
+        });
+      };
+      body.addEventListener('click', (e) => {
+        const tr = e.target.closest('tr[data-row-index]');
+        if (tr) openRowDrawer(tr);
+      });
+      body.addEventListener('keydown', (e) => {
+        const tr = e.target.closest('tr[data-row-index]');
+        if (!tr) return;
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          openRowDrawer(tr);
+          return;
+        }
+        if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+          const idx = Number(tr.dataset.rowIndex);
+          const next = e.key === 'ArrowDown' ? idx + 1 : idx - 1;
+          if (next < 0 || !gridDataRows || next >= gridDataRows.length) return;
+          e.preventDefault();
+          focusGridRow(next);
+        }
+      });
+    }
+
+    // 行数上限提示条（结果区顶部，可关闭；隐藏/显示随每次查询结果行数刷新）
+    function showRowLimitNotice(visible) {
+      let notice = document.getElementById('rowLimitNotice');
+      if (!notice) {
+        notice = document.createElement('div');
+        notice.id = 'rowLimitNotice';
+        notice.className = 'result-notice';
+        notice.setAttribute('role', 'status');
+        notice.innerHTML = '<span>结果达到服务端行数上限 (10000)，可能被截断，建议增加 LIMIT 或使用属性投影</span>' +
+          '<button class="result-notice-close" type="button" aria-label="关闭提示">✕</button>';
+        const view = document.getElementById('viewGrid');
+        view.insertBefore(notice, view.firstChild);
+        notice.querySelector('.result-notice-close').addEventListener('click', () => {
+          notice.hidden = true;
+        });
+      }
+      notice.hidden = !visible;
+    }
+
+    // 单行构建（textContent 渲染路径保持不变：XSS 安全，超长字符串走 CSS ellipsis）。
+    // 模块级函数：renderGrid 与 NDJSON 流式增量渲染（createStreamGrid）共用同一套
+    // 单元格渲染逻辑。点击/键盘打开抽屉的行为由 tbody 事件委托统一处理
+    // （虚拟滑窗下逐行绑定监听器会随窗口重建反复创建/丢弃，改为一次性委托）。
+    function buildGridRow(row, idx, cols) {
+      const tr = document.createElement('tr');
+      tr.dataset.rowIndex = String(idx);
+      // 节点行可点击标记（hover 提示 + 键盘可达；行为在 tbody 委托层）
+      const node = findNodeInRow(row);
+      if (node) {
+        tr.classList.add('row-clickable');
+        tr.tabIndex = 0;
+        tr.setAttribute('role', 'button');
+        tr.title = '点击查看该节点的 360° 视图 (Payload / Vector / Edges)';
+      }
+      cols.forEach(c => {
+        const td = document.createElement('td');
+        if (c === '#') {
+          td.textContent = idx + 1;
+          td.style.color = 'var(--text-light)';
+        } else {
+          const val = row[c];
+          if (val === undefined || val === null) {
+            td.textContent = 'null';
+            td.style.color = 'var(--text-light)';
+          } else if (typeof val === 'object') {
+            td.textContent = JSON.stringify(val);
+          } else {
+            td.textContent = String(val);
+          }
+        }
+        tr.appendChild(td);
+      });
+      return tr;
+    }
+
+    function renderGrid(rows) {
+      teardownVirtualGrid();
+      const head = document.getElementById('gridHead');
+      const body = document.getElementById('gridBody');
+      head.innerHTML = '';
+      body.innerHTML = '';
+      // 行数上限提示只在达到阈值时显示，其余结果（含空结果）一律隐藏
+      showRowLimitNotice(!!rows && rows.length >= SERVER_MAX_QUERY_ROWS);
+
+      if (!rows || rows.length === 0) {
+        head.innerHTML = '<th>#</th><th>结果</th>';
+        body.innerHTML = `<tr><td colspan="2"><div class="empty-cta">
+          <svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.5" y2="16.5"/></svg>
+          <div>查询成功，但没有匹配的行</div>
+          <button class="btn" id="emptyRunBtn" type="button">重新运行查询</button>
+        </div></td></tr>`;
+        animateResultsIn();
+        return;
+      }
+
+      // 提取全部列名
+      const colSet = new Set(['#']);
+      rows.forEach(r => Object.keys(r).forEach(k => colSet.add(k)));
+      const cols = Array.from(colSet);
+
+      // 大结果集：虚拟滑窗 —— 数据全量在内存，DOM 只建可视窗口行，spacer 撑出总滚动高度
+      if (rows.length > VIRTUAL_GRID_MIN_ROWS) {
+        gridDataRows = rows;
+        gridVirtual = createVirtualGrid(rows, cols, false);
+        animateResultsIn();
+        return;
+      }
+
+      // 小结果集：同步一次性构建（与历史行为一致，自检断言可直接读取 DOM）
+      cols.forEach(c => {
+        const th = document.createElement('th');
+        th.textContent = c;
+        head.appendChild(th);
+      });
+      gridDataRows = rows;
+      const frag = document.createDocumentFragment();
+      rows.forEach((row, idx) => frag.appendChild(buildGridRow(row, idx, cols)));
+      body.appendChild(frag);
+      animateResultsIn();
+    }
+
+    function renderMutationResult(data) {
+      teardownVirtualGrid();
+      const head = document.getElementById('gridHead');
+      const body = document.getElementById('gridBody');
+      head.innerHTML = '<th>状态</th><th>受影响行数</th><th>生成节点 ID</th>';
+      body.innerHTML = `<tr>
+        <td style="color:var(--success); font-weight:600;">✓ 写入成功</td>
+        <td>${data.affected || 0}</td>
+        <td><code>${(data.createdIds || []).join(', ') || '无'}</code></td>
+      </tr>`;
+      renderJsonTree(document.getElementById('rawJsonOutput'), data);
+      animateResultsIn();
+    }
+
+    function renderRawJson(data) {
+      renderJsonTree(document.getElementById('rawJsonOutput'), data);
+    }
+
+    function renderError(err) {
+      teardownVirtualGrid();
+      const body = document.getElementById('gridBody');
+      body.innerHTML = `<tr><td colspan="5" style="padding: 20px; background: var(--danger-bg); color: var(--danger);">
+        <strong>❌ ${err.title || '执行错误'}</strong><br>
+        <span style="font-size: 12px; margin-top: 4px; display:inline-block;">${err.detail || JSON.stringify(err)}</span>
+      </td></tr>`;
+      renderJsonTree(document.getElementById('rawJsonOutput'), err);
+      animateResultsIn();
+    }
+
+    // ==========================================
+    // 向量检索实验台 (Vector Lab)
+    // ==========================================
+    let vlCandidates = [];   // 候选节点缓存（来自选择器 TQL）
+    let vlKnownDim = null;   // 已知服务端维度（取自最近一次选中的节点向量，用于 JSON 来源的长度预校验）
+
+    function setupVectorLab() {
+      document.getElementById('vlSourceTabNode').addEventListener('click', () => switchVectorSource(true));
+      document.getElementById('vlSourceTabJson').addEventListener('click', () => switchVectorSource(false));
+      document.getElementById('vlLoadCandidatesBtn').addEventListener('click', loadVectorCandidates);
+      document.getElementById('vlNodeSelect').addEventListener('change', onVectorNodeSelected);
+      document.getElementById('vlJsonInput').addEventListener('input', updateVectorJsonPreview);
+      document.getElementById('vlRunBtn').addEventListener('click', runVectorSearch);
+    }
+
+    // 切换查询向量来源（节点选择器 / JSON 粘贴）
+    function switchVectorSource(useNode) {
+      document.getElementById('vlSourceTabNode').classList.toggle('active', useNode);
+      document.getElementById('vlSourceTabJson').classList.toggle('active', !useNode);
+      document.getElementById('vlSourceNode').hidden = !useNode;
+      document.getElementById('vlSourceJson').hidden = useNode;
+      if (!useNode) updateVectorJsonPreview();
+    }
+
+    // JSON 来源实时预览：解析成功则渲染热力条（非法输入清空预览，错误由检索时校验报告）
+    function updateVectorJsonPreview() {
+      const previewEl = document.getElementById('vlVectorPreview');
+      previewEl.textContent = '';
+      let parsed;
+      try {
+        parsed = JSON.parse(document.getElementById('vlJsonInput').value.trim());
+      } catch (_) { return; }
+      if (!Array.isArray(parsed) || !parsed.length
+        || parsed.some(v => typeof v !== 'number' || !Number.isFinite(v))) return;
+      previewEl.appendChild(renderHeatBlock(parsed, '预览'));
+    }
+
+    // 执行选择器 TQL 并将返回节点填充到下拉框
+    async function loadVectorCandidates() {
+      const btn = document.getElementById('vlLoadCandidatesBtn');
+      const select = document.getElementById('vlNodeSelect');
+      const hint = document.getElementById('vlNodeHint');
+      const query = document.getElementById('vlSelectorQuery').value.trim();
+      hint.hidden = true;
+
+      if (!query) {
+        hint.hidden = false;
+        hint.textContent = '筛选 TQL 不得为空';
+        return;
+      }
+
+      btn.disabled = true;
+      btn.textContent = '加载中...';
+      try {
+        const res = await fetch(`${API_BASE}/v1/tql`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ query, mutation: false, profile: false })
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({ title: '请求失败', detail: res.statusText }));
+          hint.hidden = false;
+          hint.textContent = `筛选查询失败: ${err.title || '未知错误'} — ${err.detail || ''}`;
+          return;
+        }
+        const data = await res.json();
+        // 行形状可能是 { 别名: 节点对象 }，提取所有带 id 的节点对象
+        const nodes = [];
+        (data.rows || []).forEach(row => {
+          Object.values(row).forEach(val => {
+            if (val && typeof val === 'object' && val.id !== undefined) nodes.push(val);
+          });
+        });
+        vlCandidates = nodes;
+        select.innerHTML = '';
+
+        if (!nodes.length) {
+          select.innerHTML = '<option value="" disabled selected>查询无结果</option>';
+          hint.hidden = false;
+          hint.textContent = '筛选查询没有返回任何节点，请调整筛选条件';
+          return;
+        }
+
+        nodes.forEach((node, idx) => {
+          const label = node.payload?.name || node.payload?.title || node.id;
+          const dimInfo = Array.isArray(node.vector) ? ` · dim=${node.vector.length}` : ' · 无向量';
+          const option = document.createElement('option');
+          option.value = idx;
+          option.textContent = `#${node.id} ${label}${dimInfo}`;
+          select.appendChild(option);
+        });
+        // 默认选中第一项并触发提示
+        select.value = '0';
+        onVectorNodeSelected();
+      } catch (err) {
+        hint.hidden = false;
+        hint.textContent = `网络请求失败: ${err.message}`;
+      } finally {
+        btn.disabled = false;
+        btn.textContent = '加载候选节点';
+      }
+    }
+
+    // 选中候选节点后给出向量预览/无向量提示
+    function onVectorNodeSelected() {
+      const select = document.getElementById('vlNodeSelect');
+      const hint = document.getElementById('vlNodeHint');
+      const node = vlCandidates[parseInt(select.value, 10)];
+      if (!node) return;
+
+      hint.hidden = false;
+      if (!Array.isArray(node.vector) || node.vector.length === 0) {
+        hint.className = 'vl-hint';
+        hint.textContent = `节点 ${node.id} 没有向量，无法作为查询向量；请换一个节点或改用 JSON 粘贴来源`;
+        return;
+      }
+      vlKnownDim = node.vector.length;
+      hint.className = 'vl-hint vl-hint--ok';
+      const preview = node.vector.slice(0, 8).map(v => Number(v.toFixed(4))).join(', ');
+      hint.textContent = `已选节点 #${node.id}，dim=${node.vector.length}，前若干维: [${preview}${node.vector.length > 8 ? ', ...' : ''}]`;
+      // 选中节点即热力条预览
+      const previewEl = document.getElementById('vlVectorPreview');
+      previewEl.textContent = '';
+      previewEl.appendChild(renderHeatBlock(node.vector, '预览'));
+    }
+
+    // 从当前激活来源解析查询向量，非法输入抛出 {title, detail}
+    function resolveQueryVector() {
+      if (!document.getElementById('vlSourceJson').hidden) {
+        const raw = document.getElementById('vlJsonInput').value.trim();
+        if (!raw) throw { title: '输入为空', detail: '请粘贴 JSON 数组形式的查询向量，例如 [0.12, -0.45, 0.78, 0.33]' };
+        let parsed;
+        try {
+          parsed = JSON.parse(raw);
+        } catch (e) {
+          throw { title: 'JSON 解析失败', detail: e.message };
+        }
+        if (!Array.isArray(parsed) || parsed.length === 0) {
+          throw { title: '格式错误', detail: '查询向量必须是非空 JSON 数组' };
+        }
+        if (parsed.some(v => typeof v !== 'number' || !Number.isFinite(v))) {
+          throw { title: '格式错误', detail: '数组元素必须全部为有限数字（不允许 NaN / Infinity / 字符串）' };
+        }
+        if (vlKnownDim !== null && parsed.length !== vlKnownDim) {
+          throw { title: '维度不匹配', detail: `输入维度 ${parsed.length} 与服务端维度 ${vlKnownDim} 不一致（维度来自最近选中的节点向量）` };
+        }
+        return parsed;
+      }
+
+      const select = document.getElementById('vlNodeSelect');
+      const node = vlCandidates[parseInt(select.value, 10)];
+      if (!node) throw { title: '未选择节点', detail: '请先加载候选节点并选择一个节点' };
+      if (!Array.isArray(node.vector) || node.vector.length === 0) {
+        throw { title: '节点无向量', detail: `节点 ${node.id} 没有向量字段，无法作为查询向量` };
+      }
+      return node.vector;
+    }
+
+    // 数值数组 → little-endian f32 二进制 body（DataView 显式小端，不依赖平台字节序）
+    function vectorToBody(values) {
+      const buffer = new ArrayBuffer(values.length * 4);
+      const view = new DataView(buffer);
+      values.forEach((v, i) => view.setFloat32(i * 4, v, true));
+      return buffer;
+    }
+
+    // 执行向量检索
+    async function runVectorSearch() {
+      const btn = document.getElementById('vlRunBtn');
+      const errEl = document.getElementById('vlSearchError');
+      errEl.hidden = true;
+
+      let vector;
+      try {
+        vector = resolveQueryVector();
+      } catch (e) {
+        errEl.textContent = `⚠ ${e.title}：${e.detail}`;
+        errEl.hidden = false;
+        return;
+      }
+
+      const topK = parseInt(document.getElementById('vlTopK').value, 10);
+      const minScore = parseFloat(document.getElementById('vlMinScore').value);
+      if (!Number.isFinite(topK) || topK < 1 || topK > 10000) {
+        errEl.textContent = '⚠ 参数错误：top_k 必须为 1-10000 之间的整数';
+        errEl.hidden = false;
+        return;
+      }
+      if (!Number.isFinite(minScore)) {
+        errEl.textContent = '⚠ 参数错误：min_score 必须为有限数字';
+        errEl.hidden = false;
+        return;
+      }
+
+      btn.disabled = true;
+      btn.textContent = '检索中...';
+      const started = performance.now();
+      try {
+        const res = await fetch(`${API_BASE}/v1/search/vector?top_k=${topK}&min_score=${String(minScore)}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/vnd.triviumdb.vector+f32' },
+          body: vectorToBody(vector)
+        });
+        const elapsed = (performance.now() - started).toFixed(1);
+        document.getElementById('statusQueryTime').textContent = `耗时: ${elapsed} ms`;
+
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({ title: '请求失败', detail: res.statusText }));
+          renderVectorSearchError(err);
+          return;
+        }
+        renderVectorResults(await res.json(), topK);
+      } catch (err) {
+        renderVectorSearchError({ title: '网络请求失败', detail: err.message });
+      } finally {
+        btn.disabled = false;
+        btn.textContent = '▶ 向量检索';
+      }
+    }
+
+    // Vector Lab 专用行内错误（风格与 renderError 一致：danger-bg + 标题 + detail）
+    function renderVectorSearchError(err) {
+      const errEl = document.getElementById('vlSearchError');
+      errEl.textContent = `❌ ${err.title || '请求失败'}\n${err.detail || JSON.stringify(err)}`;
+      errEl.hidden = false;
+      document.getElementById('vlPipeline').hidden = true;
+    }
+
+    // 渲染流水线示意 + generation + 命中表格
+    function renderVectorResults(data, topK) {
+      const hits = data.hits || [];
+
+      document.getElementById('vlPipeline').hidden = false;
+      document.getElementById('vlPipelineTopK').textContent = topK;
+      document.getElementById('vlPipelineHits').textContent = hits.length;
+      document.getElementById('vlGeneration').textContent = data.generation ? `generation: ${data.generation}` : '';
+
+      const body = document.getElementById('vlResultBody');
+      body.innerHTML = '';
+      if (!hits.length) {
+        body.innerHTML = '<tr><td colspan="4" style="text-align: center; padding: 30px; color: var(--text-light);">没有命中结果（可尝试降低 min_score 或放宽 top_k）</td></tr>';
+      } else {
+        // score 归一化比例条：以本批 hits 的 min-max 为基准；单条命中直接满条
+        const scores = hits.map(h => Number(h.score) || 0);
+        const sMin = Math.min(...scores);
+        const sMax = Math.max(...scores);
+        const sRange = sMax - sMin || 1;
+        hits.forEach((hit, idx) => {
+          const tr = document.createElement('tr');
+          const payloadText = JSON.stringify(hit.payload ?? null);
+          const payloadShort = payloadText.length > 200 ? payloadText.slice(0, 200) + '…' : payloadText;
+          const scoreNum = Number(hit.score);
+          // 单条命中或本批 score 全相同时满条，避免全部 0% 不可见
+          const t = (hits.length === 1 || sMax === sMin) ? 1 : ((scoreNum || 0) - sMin) / sRange;
+          tr.innerHTML = `
+            <td style="color: var(--text-light);">${idx + 1}</td>
+            <td style="font-family: var(--font-mono);">${hit.id}</td>
+            <td><div class="score-cell"><span style="font-family: var(--font-mono);" title="${hit.score}">${scoreNum.toFixed(6)}</span><div class="score-bar" aria-hidden="true"><i style="width: ${(t * 100).toFixed(1)}%; background: ${heatColor(t)};"></i></div></div></td>
+            <td style="font-family: var(--font-mono); font-size: 11px;" title="${payloadText.replace(/"/g, '&quot;')}">${payloadShort}</td>`;
+          body.appendChild(tr);
+        });
+      }
+      document.getElementById('vlResultTable').hidden = false;
+      document.getElementById('vlEmpty').hidden = true;
+    }
+
+    // ==========================================
+    // 拓扑图解析与 Force-Directed Canvas 渲染
+    // ==========================================
+    function renderGraph(rows) {
+      graphNodes = [];
+      graphEdges = [];
+      nodeMap = new Map();
+      graphTotalNodeCount = 0;
+      const seenIds = new Set(); // 全量节点计数去重（含被截断未渲染的节点）
+
+      // 从结果中抽取所有节点与边对象
+      rows.forEach((row) => {
+        const rowNodeIds = [];
+        Object.entries(row).forEach(([key, val]) => {
+          if (val && typeof val === 'object') {
+            if (val.id !== undefined) {
+              // 节点：先无差别计数（真实总节点数），再按渲染上限截断
+              const id = String(val.id);
+              if (!seenIds.has(id)) {
+                seenIds.add(id);
+                graphTotalNodeCount++;
+              }
+              if (nodeMap.has(id) || graphNodes.length >= GRAPH_RENDER_MAX_NODES) {
+                // 已渲染过、或达到渲染上限：只参与计数，不再创建；
+                // 连线推断也只对已渲染节点做，避免无效边堆积
+                if (nodeMap.has(id)) rowNodeIds.push(id);
+                return;
+              }
+              // 黄金角螺旋初始位置：相比纯随机可显著减少初始重叠
+              const idx = nodeMap.size;
+              const radius = 30 + idx * 11;
+              const node = {
+                id,
+                label: val.payload?.name || val.payload?.title || `Node ${id}`,
+                typeKey: val.payload?.type || key, // 着色模式切回「按类型」时的还原依据
+                payload: val.payload || {},
+                vector: val.vector || [],
+                x: Math.cos(idx * 2.399963) * radius,
+                y: Math.sin(idx * 2.399963) * radius,
+                vx: 0,
+                vy: 0,
+                color: getNodeColor(val.payload?.type || key)
+              };
+              nodeMap.set(id, node);
+              graphNodes.push(node);
+              rowNodeIds.push(id);
+            } else if (val.source !== undefined && val.target !== undefined) {
+              // 边
+              graphEdges.push({
+                source: String(val.source),
+                target: String(val.target),
+                label: val.label || 'LINK'
+              });
+            }
+          }
+        });
+        // TQL 的 MATCH 投影只能返回节点对象而无法返回边，
+        // 同一行内先后出现的节点按返回顺序推断连线关系（仅限已渲染节点）
+        for (let i = 1; i < rowNodeIds.length; i++) {
+          graphEdges.push({ source: rowNodeIds[i - 1], target: rowNodeIds[i], label: '' });
+        }
+      });
+
+      applyGraphPhysicsPolicy();
+      // WebGL 后端下新数据到达：按当前着色模式重建 Sigma 实例
+      if (graphBackend === 'sigma') {
+        if (graphColorMode === 'community') applyCommunityColors();
+        else rebuildSigmaInstances();
+      }
+    }
+
+    // 规模护栏分流：>1500 只渲染（物理必关），300<n≤1500 关物理保静态布局，
+    // ≤300 维持原力导向行为（用户手动冻结状态不受影响）
+    function applyGraphPhysicsPolicy() {
+      const btn = document.getElementById('togglePhysicsBtn');
+      if (graphNodes.length > GRAPH_PHYSICS_MAX_NODES) {
+        physicsLockedByScale = true;
+        simulationRunning = false;
+        if (btn) btn.textContent = '恢复力学';
+      } else {
+        // 上一轮因规模被锁、本轮规模回落：自动恢复可模拟状态；
+        // 用户主动冻结（physicsLockedByScale=false 且 simulationRunning=false）则保持冻结
+        const resumeAfterScaleLock = physicsLockedByScale;
+        physicsLockedByScale = false;
+        if (resumeAfterScaleLock) {
+          simulationRunning = true;
+          if (btn) btn.textContent = '冻结力学';
+        }
+        startSimulation(1);
+      }
+      updateGraphScaleNotice();
+      // 物理被禁用时没有 rAF 重绘循环，需立即绘制一次静态布局
+      // （画布容器隐藏时 redrawGraph 内部会跳过尺寸同步，切到图视图时还有一次重绘兜底）
+      if (physicsLockedByScale) redrawGraph();
+    }
+
+    // 图视图规模提示条：>1500 显示截断文案，300<n≤1500 显示暂停力学文案，≤300 隐藏
+    function updateGraphScaleNotice() {
+      const notice = document.getElementById('graphScaleNotice');
+      if (!notice) return;
+      let msg = '';
+      if (graphNodes.length >= GRAPH_RENDER_MAX_NODES && graphTotalNodeCount > graphNodes.length) {
+        msg = `共 ${graphTotalNodeCount} 个节点，仅渲染前 ${GRAPH_RENDER_MAX_NODES}（已暂停力学模拟以保持流畅）`;
+      } else if (physicsLockedByScale) {
+        msg = `节点数 ${graphNodes.length} 超过 ${GRAPH_PHYSICS_MAX_NODES}，已暂停力学模拟以保持流畅`;
+      }
+      notice.hidden = !msg;
+      if (msg) notice.querySelector('span').textContent = msg;
+    }
+
+    // ==========================================
+    // 力导向布局引擎（斥力 + 弹簧 + 向心力，冷却收敛后自动停止）
+    // ==========================================
+    function startSimulation(alpha) {
+      simulationAlpha = Math.max(simulationAlpha, alpha);
+      if (simulationRafId === null) {
+        simulationRafId = requestAnimationFrame(simulationStep);
+      }
+    }
+
+    function simulationStep() {
+      if (simulationRunning && graphNodes.length > 0 && simulationAlpha > 0.005) {
+        tickPhysics();
+        redrawGraph();
+        simulationAlpha *= 0.982;
+        simulationRafId = requestAnimationFrame(simulationStep);
+      } else {
+        simulationRafId = null;
+      }
+    }
+
+    function tickPhysics() {
+      const nodes = graphNodes;
+      const count = nodes.length;
+      if (count === 0) return;
+      // 库仑斥力 + 最小间距约束：避免节点堆叠
+      const repulsion = 9000;
+      const minDist = 56;
+      for (let i = 0; i < count; i++) {
+        for (let j = i + 1; j < count; j++) {
+          const a = nodes[i];
+          const b = nodes[j];
+          let dx = a.x - b.x;
+          let dy = a.y - b.y;
+          let distSq = dx * dx + dy * dy;
+          if (distSq < 1) {
+            dx = Math.random() - 0.5 || 0.1;
+            dy = Math.random() - 0.5 || 0.1;
+            distSq = dx * dx + dy * dy;
+          }
+          const dist = Math.sqrt(distSq);
+          const force = repulsion / distSq + (dist < minDist ? (minDist - dist) * 0.8 : 0);
+          const fx = (dx / dist) * force;
+          const fy = (dy / dist) * force;
+          a.vx += fx;
+          a.vy += fy;
+          b.vx -= fx;
+          b.vy -= fy;
+        }
+      }
+      // 弹簧力：有边相连的节点向理想长度聚拢（对应官网风格中关系紧密节点彼此靠近）
+      const springLength = 130;
+      const stiffness = 0.015;
+      for (const edge of graphEdges) {
+        const s = nodeMap.get(edge.source);
+        const t = nodeMap.get(edge.target);
+        if (!s || !t) continue;
+        const dx = t.x - s.x;
+        const dy = t.y - s.y;
+        const dist = Math.hypot(dx, dy) || 0.1;
+        const force = (dist - springLength) * stiffness;
+        const fx = (dx / dist) * force;
+        const fy = (dy / dist) * force;
+        s.vx += fx;
+        s.vy += fy;
+        t.vx -= fx;
+        t.vy -= fy;
+      }
+      // 向心力 + 阻尼积分：整体收拢在视口中心附近并逐渐静止
+      const canvas = document.getElementById('graphCanvas');
+      const halfW = (canvas ? canvas.width : 800) / 2 - 70;
+      const halfH = (canvas ? canvas.height : 600) / 2 - 70;
+      for (const node of nodes) {
+        node.vx -= node.x * 0.002;
+        node.vy -= node.y * 0.002;
+        // 软边界：越界节点受回拉力，保证布局始终落在画布内
+        if (node.x < -halfW) node.vx += (-halfW - node.x) * 0.05;
+        if (node.x > halfW) node.vx += (halfW - node.x) * 0.05;
+        if (node.y < -halfH) node.vy += (-halfH - node.y) * 0.05;
+        if (node.y > halfH) node.vy += (halfH - node.y) * 0.05;
+        node.vx *= 0.82;
+        node.vy *= 0.82;
+        node.x += node.vx * simulationAlpha;
+        node.y += node.vy * simulationAlpha;
+      }
+    }
+
+    function getNodeColor(type) {
+      const colors = {
+        person: '#3b82f6',
+        paper: '#10b981',
+        topic: '#8b5cf6',
+        user: '#f59e0b',
+        event: '#ec4899'
+      };
+      return colors[type] || '#0284c7';
+    }
+
+    function initCanvas(canvasId) {
+      const canvas = document.getElementById(canvasId);
+      if (!canvas) return;
+      const ctx = canvas.getContext('2d');
+
+      function resize() {
+        canvas.width = canvas.parentElement.clientWidth;
+        canvas.height = canvas.parentElement.clientHeight;
+        transform.x = canvas.width / 2;
+        transform.y = canvas.height / 2;
+        redrawGraph();
+      }
+      window.addEventListener('resize', resize);
+      setTimeout(resize, 100);
+
+      // 拖拽与缩放
+      canvas.addEventListener('mousedown', (e) => {
+        const rect = canvas.getBoundingClientRect();
+        const mx = (e.clientX - rect.left - transform.x) / transform.k;
+        const my = (e.clientY - rect.top - transform.y) / transform.k;
+
+        // 碰撞测试
+        const clickedNode = graphNodes.find(n => Math.hypot(n.x - mx, n.y - my) < 20);
+        if (clickedNode) {
+          draggedNode = clickedNode;
+          selectedNode = clickedNode;
+          openNodeDrawer(clickedNode);
+        } else {
+          isDraggingCanvas = true;
+          dragStart = { x: e.clientX, y: e.clientY };
+        }
+      });
+
+      window.addEventListener('mousemove', (e) => {
+        if (draggedNode) {
+          const rect = canvas.getBoundingClientRect();
+          draggedNode.x = (e.clientX - rect.left - transform.x) / transform.k;
+          draggedNode.y = (e.clientY - rect.top - transform.y) / transform.k;
+          if (simulationRunning) startSimulation(0.3);
+          redrawGraph();
+        } else if (isDraggingCanvas) {
+          transform.x += e.clientX - dragStart.x;
+          transform.y += e.clientY - dragStart.y;
+          dragStart = { x: e.clientX, y: e.clientY };
+          redrawGraph();
+        }
+      });
+
+      window.addEventListener('mouseup', () => {
+        draggedNode = null;
+        isDraggingCanvas = false;
+      });
+
+      canvas.addEventListener('wheel', (e) => {
+        e.preventDefault();
+        const zoom = e.deltaY < 0 ? 1.1 : 0.9;
+        transform.k *= zoom;
+        redrawGraph();
+      });
+
+      document.getElementById('centerGraphBtn').addEventListener('click', () => {
+        transform.x = canvas.width / 2;
+        transform.y = canvas.height / 2;
+        transform.k = 1;
+        redrawGraph();
+      });
+
+      document.getElementById('togglePhysicsBtn').addEventListener('click', () => {
+        // 规模护栏禁用物理时（>300 节点），「恢复力学」不被允许，给出 toast 说明
+        if (physicsLockedByScale) {
+          showToast(`节点数超过 ${GRAPH_PHYSICS_MAX_NODES}，力学模拟已停用以保持流畅`);
+          return;
+        }
+        simulationRunning = !simulationRunning;
+        document.getElementById('togglePhysicsBtn').textContent = simulationRunning ? '冻结力学' : '恢复力学';
+        if (simulationRunning) startSimulation(0.5);
+      });
+
+      document.getElementById('closeDrawerBtn').addEventListener('click', () => {
+        document.getElementById('nodeDrawer').classList.remove('open');
+      });
+    }
+
+    function redrawGraph() {
+      const canvas = document.getElementById('graphCanvas');
+      if (!canvas) return;
+      // 画布可能在容器隐藏（display:none）时被初始化为 0 尺寸，
+      // 切换到图视图后需先同步到当前布局，否则永远画不出内容
+      if (syncCanvasSize(canvas)) {
+        transform.x = canvas.width / 2;
+        transform.y = canvas.height / 2;
+      }
+      if (graphBackend === 'canvas') {
+        drawGraphScene(canvas.getContext('2d'), transform, canvas);
+      }
+      // 独立探索画布：同一图数据的第二 canvas 视图（可见且 canvas 后端时绘制）
+      const sa = document.getElementById('standaloneGraphCanvas');
+      if (sa && graphBackend === 'canvas' && sa.parentElement && sa.parentElement.clientWidth > 0) {
+        if (syncCanvasSize(sa)) {
+          standaloneTransform.x = sa.width / 2;
+          standaloneTransform.y = sa.height / 2;
+        }
+        drawGraphScene(sa.getContext('2d'), standaloneTransform, sa);
+      }
+      syncSigmaPositions();
+    }
+
+    // 画布尺寸与父容器同步（隐藏容器 clientWidth=0 时跳过）
+    function syncCanvasSize(canvas) {
+      const parent = canvas.parentElement;
+      if (parent && parent.clientWidth > 0
+        && (canvas.width !== parent.clientWidth || canvas.height !== parent.clientHeight)) {
+        canvas.width = parent.clientWidth;
+        canvas.height = parent.clientHeight;
+        return true;
+      }
+      return false;
+    }
+
+    // 场景绘制：把当前图数据按相机变换画到一个 canvas 上
+    function drawGraphScene(ctx, t, canvas) {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      ctx.save();
+      ctx.translate(t.x, t.y);
+      ctx.scale(t.k, t.k);
+
+      // 绘制连线
+      graphEdges.forEach(edge => {
+        const s = graphNodes.find(n => n.id === edge.source);
+        const t = graphNodes.find(n => n.id === edge.target);
+        if (s && t) {
+          ctx.beginPath();
+          ctx.moveTo(s.x, s.y);
+          ctx.lineTo(t.x, t.y);
+          ctx.strokeStyle = document.documentElement.getAttribute('data-theme') === 'dark' ? '#334155' : '#cbd5e1';
+          ctx.lineWidth = 1.5;
+          ctx.stroke();
+
+          // 绘制标签
+          if (edge.label) {
+            const midX = (s.x + t.x) / 2;
+            const midY = (s.y + t.y) / 2;
+            ctx.fillStyle = '#64748b';
+            ctx.font = '10px ' + CANVAS_FONT_FAMILY;
+            ctx.fillText(edge.label, midX, midY - 3);
+          }
+        }
+      });
+
+      // 绘制节点
+      graphNodes.forEach(node => {
+        ctx.beginPath();
+        ctx.arc(node.x, node.y, 16, 0, Math.PI * 2);
+        ctx.fillStyle = node.color;
+        ctx.fill();
+        ctx.strokeStyle = selectedNode === node ? '#ffffff' : 'rgba(0,0,0,0.15)';
+        ctx.lineWidth = selectedNode === node ? 3 : 1;
+        ctx.stroke();
+
+        // 文字
+        ctx.fillStyle = document.documentElement.getAttribute('data-theme') === 'dark' ? '#f1f5f9' : '#1e293b';
+        ctx.font = '11px ' + CANVAS_FONT_FAMILY;
+        ctx.textAlign = 'center';
+        ctx.fillText(node.label, node.x, node.y + 28);
+      });
+
+      ctx.restore();
+    }
+
+    // ==========================================
+    // 图渲染器抽象（PR-13）：Canvas（内建力导向）与 Sigma.js WebGL 双后端
+    // 两个图入口（查询图视图 graphCanvas / 独立探索 standaloneGraphCanvas）共享
+    // graphNodes/graphEdges 数据；后端与着色模式为全局状态，两视图按钮同步。
+    // graphology / sigma / graphology-communities 均经 CDN 按需加载，
+    // 加载失败自动回退 Canvas 并 toast 提示（离线环境功能不降级缺失）。
+    // ==========================================
+    const SIGMA_CDN = {
+      graphology: 'https://cdn.jsdelivr.net/npm/graphology@0.25.4/dist/graphology.umd.min.js',
+      // sigma@2.4.0 的浏览器 IIFE 构建在包根目录（var Sigma = ...），dist 下只有 CJS
+      sigma: 'https://cdn.jsdelivr.net/npm/sigma@2.4.0/build/sigma.min.js',
+      // graphology-communities-louvain 无 UMD 构建：走 jsDelivr ESM CDN（/+esm）动态 import
+      communities: 'https://cdn.jsdelivr.net/npm/graphology-communities-louvain@2.0.2/+esm'
+    };
+    const COMMUNITY_PALETTE = [
+      '#e6194b', '#3cb44b', '#4363d8', '#f58231', '#911eb4',
+      '#46f0f0', '#f032e6', '#bcf60c', '#fabebe', '#008080',
+      '#9a6324', '#800000', '#808000', '#000075', '#a9a9a9'
+    ];
+    let graphBackend = 'canvas';     // 'canvas' | 'sigma'（全局后端，两视图一致）
+    let graphColorMode = 'type';     // 'type' | 'community'（全局着色模式）
+    let standaloneTransform = { x: 0, y: 0, k: 1 }; // 独立画布独立相机
+    let sigmaLibs = null;            // { Sigma, Graph }（CDN 加载后缓存）
+    let communitiesLib = null;       // { louvain }
+    let sigmaLoadPromise = null;
+    let communitiesLoadPromise = null;
+    let nodeCommunities = new Map(); // nodeId -> 社区 key（社区着色模式下）
+    const sigmaInstances = { query: null, standalone: null }; // { sigma, graph, mapFn }
+
+    // 脚本标签加载器（selftest 可整体替换以注入 fake 库，离线可测）
+    function loadScriptTag(src) {
+      return new Promise((resolve, reject) => {
+        const el = document.createElement('script');
+        el.src = src;
+        el.async = true;
+        el.onload = () => resolve();
+        el.onerror = () => { el.remove(); reject(new Error('脚本加载失败: ' + src)); };
+        document.head.appendChild(el);
+      });
+    }
+
+    // Sigma + graphology 按需加载（promise 缓存；失败清缓存允许重试）
+    function loadSigmaLibs() {
+      if (sigmaLibs) return Promise.resolve(sigmaLibs);
+      if (!sigmaLoadPromise) {
+        sigmaLoadPromise = (async () => {
+          if (!window.graphology) await loadScriptTag(SIGMA_CDN.graphology);
+          if (!window.Sigma) await loadScriptTag(SIGMA_CDN.sigma);
+          if (!window.graphology || !window.Sigma) throw new Error('CDN 库加载不完整');
+          sigmaLibs = { Sigma: window.Sigma, Graph: window.graphology.Graph };
+          return sigmaLibs;
+        })().catch((err) => { sigmaLoadPromise = null; throw err; });
+      }
+      return sigmaLoadPromise;
+    }
+
+    // Louvain 社区检测模块加载器（可注入点：selftest 替换为 fake，离线可测）。
+    // louvain 包无 UMD 构建，默认走 jsDelivr ESM CDN（/+esm）动态 import
+    let loadCommunitiesModule = () => import(SIGMA_CDN.communities);
+
+    function loadCommunitiesLib() {
+      if (communitiesLib) return Promise.resolve(communitiesLib);
+      if (!communitiesLoadPromise) {
+        communitiesLoadPromise = (async () => {
+          if (!window.graphology) await loadScriptTag(SIGMA_CDN.graphology);
+          const mod = await loadCommunitiesModule();
+          // ESM 构建的导出形状兼容：{ louvain } / { default: louvainFn } / { default: { louvain } }
+          const louvain = mod.louvain
+            || (mod.default && (typeof mod.default === 'function' ? mod.default : mod.default.louvain));
+          if (!louvain) throw new Error('社区检测库加载不完整');
+          communitiesLib = { louvain };
+          return communitiesLib;
+        })().catch((err) => { communitiesLoadPromise = null; throw err; });
+      }
+      return communitiesLoadPromise;
+    }
+
+    // 引擎坐标（画布像素、中心原点）→ Sigma 图空间 [0,1]，线性映射随 bbox 重建
+    function sigmaMapFactory() {
+      let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+      graphNodes.forEach(n => {
+        if (n.x < minX) minX = n.x;
+        if (n.x > maxX) maxX = n.x;
+        if (n.y < minY) minY = n.y;
+        if (n.y > maxY) maxY = n.y;
+      });
+      const span = Math.max(maxX - minX, maxY - minY) * 1.1 || 1;
+      const cx = (minX + maxX) / 2;
+      const cy = (minY + maxY) / 2;
+      return (n) => ({ x: (n.x - cx) / span + 0.5, y: (n.y - cy) / span + 0.5 });
+    }
+
+    // 为单个视图构建 Sigma 实例（位置来自共享力导向引擎，WebGL 只负责渲染加速）
+    function buildSigmaForView(viewId) {
+      if (!sigmaLibs) return;
+      const container = document.getElementById(viewId === 'query' ? 'graphSigmaContainer' : 'standaloneSigmaContainer');
+      if (!container) return;
+      destroySigmaInstance(viewId);
+      const mapFn = sigmaMapFactory();
+      const graph = new sigmaLibs.Graph();
+      const dark = document.documentElement.getAttribute('data-theme') === 'dark';
+      graphNodes.forEach(n => {
+        const p = mapFn(n);
+        graph.addNode(n.id, { x: p.x, y: p.y, size: 7, label: n.label, color: n.color });
+      });
+      graphEdges.forEach(e => {
+        if (graph.hasNode(e.source) && graph.hasNode(e.target) && !graph.hasEdge(e.source, e.target)) {
+          graph.addEdge(e.source, e.target, { size: 1, color: dark ? '#334155' : '#cbd5e1' });
+        }
+      });
+      const sigma = new sigmaLibs.Sigma(graph, container, {
+        allowInvalidContainer: true,
+        defaultEdgeColor: dark ? '#334155' : '#cbd5e1',
+        labelColor: { color: dark ? '#f1f5f9' : '#1e293b' },
+        labelDensity: 1.2,
+        minCameraRatio: 0.05,
+        maxCameraRatio: 20
+      });
+      // 节点点击 → 360° 抽屉（与 Canvas 后端行为一致）
+      sigma.on('clickNode', ({ node }) => {
+        const gnode = nodeMap.get(node);
+        if (gnode) openNodeDrawer(gnode);
+      });
+      sigmaInstances[viewId] = { sigma, graph, mapFn };
+    }
+
+    function destroySigmaInstance(viewId) {
+      const inst = sigmaInstances[viewId];
+      if (!inst) return;
+      try { inst.sigma.kill(); } catch (_) { /* 已销毁 */ }
+      sigmaInstances[viewId] = null;
+    }
+
+    function destroySigmaInstances() {
+      destroySigmaInstance('query');
+      destroySigmaInstance('standalone');
+    }
+
+    function rebuildSigmaInstances() {
+      if (!sigmaLibs) return;
+      buildSigmaForView('query');
+      buildSigmaForView('standalone');
+    }
+
+    // 力导向引擎每帧推进共享坐标后，把位置同步进 Sigma 并刷新（WebGL 渲染循环）
+    function syncSigmaPositions() {
+      if (graphBackend !== 'sigma') return;
+      for (const viewId of ['query', 'standalone']) {
+        const inst = sigmaInstances[viewId];
+        if (!inst || inst.sigma.killed) continue;
+        const container = inst.sigma.getContainer ? inst.sigma.getContainer() : null;
+        if (container && (container.offsetParent === null || container.clientWidth === 0)) continue;
+        inst.graph.forEachNode((id) => {
+          const n = nodeMap.get(id);
+          if (!n) return;
+          const p = inst.mapFn(n);
+          inst.graph.setNodeAttribute(id, 'x', p.x);
+          inst.graph.setNodeAttribute(id, 'y', p.y);
+        });
+        inst.sigma.refresh();
+      }
+    }
+
+    // 后端切换：sigma 需先按需加载 CDN 库，失败则回退 canvas + toast（离线降级）
+    async function setGraphBackend(mode) {
+      if (mode === graphBackend) return;
+      const buttons = ['toggleWebGLBtn', 'toggleWebGLBtnStandalone']
+        .map(id => document.getElementById(id)).filter(Boolean);
+      if (mode === 'sigma') {
+        buttons.forEach(b => { b.disabled = true; });
+        let libs;
+        try {
+          libs = await loadSigmaLibs();
+        } catch (err) {
+          buttons.forEach(b => { b.disabled = false; });
+          showToast('WebGL 渲染库加载失败（离线或 CDN 不可达），已保持 Canvas 渲染');
+          syncBackendButtons();
+          return;
+        }
+        graphBackend = 'sigma';
+        ['graphSigmaContainer', 'standaloneSigmaContainer'].forEach(id => {
+          const el = document.getElementById(id);
+          if (el) el.hidden = false;
+        });
+        rebuildSigmaInstances();
+        buttons.forEach(b => { b.disabled = false; });
+      } else {
+        graphBackend = 'canvas';
+        destroySigmaInstances();
+        ['graphSigmaContainer', 'standaloneSigmaContainer'].forEach(id => {
+          const el = document.getElementById(id);
+          if (el) el.hidden = true;
+        });
+        redrawGraph();
+      }
+      syncBackendButtons();
+    }
+
+    function syncBackendButtons() {
+      ['toggleWebGLBtn', 'toggleWebGLBtnStandalone'].forEach(id => {
+        const btn = document.getElementById(id);
+        if (btn) btn.textContent = graphBackend === 'sigma' ? 'Canvas 渲染' : 'WebGL 渲染';
+      });
+    }
+
+    // 着色模式切换：按类型（三模语义色）/ 按社区（Louvain，按需加载，默认按类型）
+    async function setGraphColorMode(mode) {
+      if (mode === graphColorMode) return;
+      if (mode === 'type') {
+        graphColorMode = 'type';
+        nodeCommunities = new Map();
+        graphNodes.forEach(n => { n.color = getNodeColor(n.typeKey); });
+        updateGraphLegend();
+        refreshGraphColors();
+        syncColorModeButtons();
+        return;
+      }
+      graphColorMode = 'community';
+      syncColorModeButtons();
+      const ok = await applyCommunityColors();
+      if (!ok) {
+        graphColorMode = 'type';
+        syncColorModeButtons();
+      }
+    }
+
+    // 对当前图跑 Louvain 社区检测并按社区重新着色 + 更新图例；失败返回 false
+    async function applyCommunityColors() {
+      let louvain;
+      try {
+        ({ louvain } = await loadCommunitiesLib());
+      } catch (err) {
+        showToast('社区检测库加载失败（离线或 CDN 不可达），已回退按类型着色');
+        graphNodes.forEach(n => { n.color = getNodeColor(n.typeKey); });
+        nodeCommunities = new Map();
+        updateGraphLegend();
+        refreshGraphColors();
+        return false;
+      }
+      const GraphCtor = (sigmaLibs && sigmaLibs.Graph) || window.graphology.Graph;
+      const g = new GraphCtor();
+      graphNodes.forEach(n => { try { g.addNode(n.id); } catch (_) { /* 重复 id */ } });
+      const ids = new Set(graphNodes.map(n => n.id));
+      const seen = new Set();
+      graphEdges.forEach(e => {
+        const key = [e.source, e.target].sort().join('|');
+        if (!ids.has(e.source) || !ids.has(e.target) || seen.has(key) || e.source === e.target) return;
+        seen.add(key);
+        try { g.addEdge(e.source, e.target); } catch (_) { /* 非法边 */ }
+      });
+      const result = louvain(g) || {};
+      // 加载期间用户切回按类型：丢弃社区结果（graphColorMode 已被同步改写）
+      if (graphColorMode !== 'community') { updateGraphLegend(); return true; }
+      nodeCommunities = new Map(Object.entries(result));
+      const communityKeys = [];
+      nodeCommunities.forEach(k => { if (!communityKeys.includes(k)) communityKeys.push(k); });
+      nodeCommunities.forEach((k, id) => {
+        const node = nodeMap.get(id);
+        if (node) node.color = COMMUNITY_PALETTE[communityKeys.indexOf(k) % COMMUNITY_PALETTE.length];
+      });
+      updateGraphLegend(communityKeys);
+      refreshGraphColors();
+      return true;
+    }
+
+    // 图例：仅社区模式显示（社区 N + 节点数），两个视图同步
+    function updateGraphLegend(communityKeys) {
+      ['graphLegend', 'graphLegendStandalone'].forEach(legendId => {
+        const legend = document.getElementById(legendId);
+        if (!legend) return;
+        legend.textContent = '';
+        if (graphColorMode !== 'community' || !communityKeys || !communityKeys.length || !nodeCommunities.size) {
+          legend.hidden = true;
+          return;
+        }
+        legend.hidden = false;
+        communityKeys.forEach((key, i) => {
+          let count = 0;
+          nodeCommunities.forEach(k => { if (k === key) count++; });
+          const chip = document.createElement('span');
+          chip.className = 'legend-chip';
+          const swatch = document.createElement('i');
+          swatch.className = 'legend-swatch';
+          swatch.style.background = COMMUNITY_PALETTE[i % COMMUNITY_PALETTE.length];
+          chip.appendChild(swatch);
+          const text = document.createElement('span');
+          text.textContent = `社区 ${i + 1} (${count})`;
+          chip.appendChild(text);
+          legend.appendChild(chip);
+        });
+      });
+    }
+
+    function refreshGraphColors() {
+      if (graphBackend === 'sigma') {
+        for (const viewId of ['query', 'standalone']) {
+          const inst = sigmaInstances[viewId];
+          if (!inst || inst.sigma.killed) continue;
+          graphNodes.forEach(n => {
+            if (inst.graph.hasNode(n.id)) inst.graph.setNodeAttribute(n.id, 'color', n.color);
+          });
+          inst.sigma.refresh();
+        }
+      } else {
+        redrawGraph();
+      }
+    }
+
+    function syncColorModeButtons() {
+      [['colorModeTypeBtn', 'type'], ['colorModeTypeBtnStandalone', 'type'],
+       ['colorModeCommunityBtn', 'community'], ['colorModeCommunityBtnStandalone', 'community']]
+        .forEach(([id, mode]) => {
+          const btn = document.getElementById(id);
+          if (btn) btn.classList.toggle('active', graphColorMode === mode);
+        });
+    }
+
+    // 渲染器控制按钮绑定（DOMContentLoaded 调用一次）
+    function setupGraphRenderers() {
+      ['toggleWebGLBtn', 'toggleWebGLBtnStandalone'].forEach(id => {
+        document.getElementById(id).addEventListener('click', () => {
+          setGraphBackend(graphBackend === 'canvas' ? 'sigma' : 'canvas');
+        });
+      });
+      [['colorModeTypeBtn', 'type'], ['colorModeTypeBtnStandalone', 'type'],
+       ['colorModeCommunityBtn', 'community'], ['colorModeCommunityBtnStandalone', 'community']]
+        .forEach(([id, mode]) => {
+          document.getElementById(id).addEventListener('click', () => { setGraphColorMode(mode); });
+        });
+      document.getElementById('centerStandaloneBtn').addEventListener('click', () => {
+        const sa = document.getElementById('standaloneGraphCanvas');
+        standaloneTransform = { x: sa.width / 2, y: sa.height / 2, k: 1 };
+        redrawGraph();
+      });
+
+      // 独立画布交互：点击节点开抽屉 / 拖拽平移 / 滚轮缩放（与查询图视图行为一致）
+      const saCanvas = document.getElementById('standaloneGraphCanvas');
+      let saDragging = false;
+      let saDragStart = null;
+      saCanvas.addEventListener('mousedown', (e) => {
+        const rect = saCanvas.getBoundingClientRect();
+        const mx = (e.clientX - rect.left - standaloneTransform.x) / standaloneTransform.k;
+        const my = (e.clientY - rect.top - standaloneTransform.y) / standaloneTransform.k;
+        const hit = graphNodes.find(n => Math.hypot(n.x - mx, n.y - my) < 20);
+        if (hit) {
+          openNodeDrawer(hit);
+        } else {
+          saDragging = true;
+          saDragStart = { x: e.clientX, y: e.clientY };
+        }
+      });
+      window.addEventListener('mousemove', (e) => {
+        if (!saDragging) return;
+        standaloneTransform.x += e.clientX - saDragStart.x;
+        standaloneTransform.y += e.clientY - saDragStart.y;
+        saDragStart = { x: e.clientX, y: e.clientY };
+        redrawGraph();
+      });
+      window.addEventListener('mouseup', () => { saDragging = false; });
+      saCanvas.addEventListener('wheel', (e) => {
+        e.preventDefault();
+        standaloneTransform.k *= e.deltaY < 0 ? 1.1 : 0.9;
+        redrawGraph();
+      });
+    }
+
+    // ==========================================
+    // 节点 360° 详情抽屉 (Trinity 三平面: Payload / Vector / Edges)
+    // ==========================================
+    function openNodeDrawer(node) {
+      document.getElementById('drawerNodeTitle').textContent = `节点: #${node.id} (${node.label})`;
+
+      // 平面 1: Payload（可折叠 JSON 树）
+      renderJsonTree(document.getElementById('drawerNodePayload'), node.payload ?? {});
+
+      // 平面 2: Vector（维度 + 前 16 维数值，超长折叠）
+      renderDrawerVector(node.vector || []);
+
+      // 平面 3: Edges（异步拉取 GET /v1/nodes/{id} 的 edgeVersions）
+      loadNodeEdges(node.id);
+
+      document.getElementById('nodeDrawer').classList.add('open');
+    }
+
+    // Vector 平面：热力条（min-max 归一顺序色带，hover 显示 dim/数值）+ 摘要（dim 数与 L2 范数），
+    // 原始精确数值保留在折叠的 <details> 中
+    function renderDrawerVector(vector) {
+      const container = document.getElementById('drawerNodeVector');
+      container.textContent = '';
+      if (!Array.isArray(vector) || vector.length === 0) {
+        container.innerHTML = '<span class="inspector-vector-summary">无向量 (no vector attached)</span>';
+        return;
+      }
+      container.appendChild(renderHeatBlock(vector));
+      const details = document.createElement('details');
+      const sum = document.createElement('summary');
+      sum.textContent = `全部 ${vector.length} 维数值`;
+      sum.style.cssText = 'cursor: pointer; color: var(--primary); font-size: 11px; margin-top: 6px;';
+      const chips = document.createElement('div');
+      chips.style.cssText = 'margin-top: 6px;';
+      chips.innerHTML = vector.map(v => `<span class="inspector-vector-chip">${Number(v).toFixed(4)}</span>`).join('');
+      details.appendChild(sum);
+      details.appendChild(chips);
+      container.appendChild(details);
+    }
+
+    // Edges 平面：GET /v1/nodes/{id}，渲染 edgeVersions 的 target/label 列表
+    async function loadNodeEdges(nodeId) {
+      const container = document.getElementById('drawerNodeEdges');
+      container.textContent = '加载中...';
+      try {
+        const res = await fetch(`${API_BASE}/v1/nodes/${nodeId}`);
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({ title: '请求失败', detail: res.statusText }));
+          container.innerHTML = `<div class="inspector-hint">边信息加载失败: ${err.title || '未知错误'} — ${err.detail || ''}</div>`;
+          return;
+        }
+        const data = await res.json();
+        const edges = data.edgeVersions || [];
+
+        if (!edges.length) {
+          container.textContent = '无出边 (no outgoing edges)';
+          return;
+        }
+        container.innerHTML = '';
+        edges.forEach(edge => {
+          const item = document.createElement('div');
+          item.className = 'inspector-edge-item';
+          // target 可点击：跳转继续查看该节点
+          item.innerHTML = `
+            <span class="inspector-edge-label">${edge.label ?? '-'}</span>
+            <span>→</span>
+            <button class="inspector-edge-target" type="button" title="查看节点 #${edge.targetId} 的 360° 视图">#${edge.targetId}</button>`;
+          item.querySelector('.inspector-edge-target').addEventListener('click', () => jumpToNode(edge.targetId));
+          container.appendChild(item);
+        });
+      } catch (err) {
+        container.innerHTML = `<div class="inspector-hint">网络请求失败: ${err.message}</div>`;
+      }
+    }
+
+    // 从边列表跳转到目标节点：拉取完整节点数据后重新渲染抽屉
+    async function jumpToNode(nodeId) {
+      const container = document.getElementById('drawerNodeEdges');
+      container.textContent = '加载中...';
+      try {
+        const res = await fetch(`${API_BASE}/v1/nodes/${nodeId}`);
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({ title: '请求失败', detail: res.statusText }));
+          container.innerHTML = `<div class="inspector-hint">节点 #${nodeId} 加载失败: ${err.title || '未知错误'} — ${err.detail || ''}</div>`;
+          return;
+        }
+        const data = await res.json();
+        const node = data.node || {};
+        openNodeDrawer({
+          id: node.id ?? nodeId,
+          label: node.payload?.name || node.payload?.title || `Node ${nodeId}`,
+          payload: node.payload || {},
+          vector: node.vector || []
+        });
+      } catch (err) {
+        container.innerHTML = `<div class="inspector-hint">网络请求失败: ${err.message}</div>`;
+      }
+    }
+
+    // 从表格行中提取节点对象（行形状可能是 { 别名: 节点对象 } 或混合值）
+    function findNodeInRow(row) {
+      for (const val of Object.values(row)) {
+        if (val && typeof val === 'object' && !Array.isArray(val) && val.id !== undefined && val.type === 'node') {
+          return val;
+        }
+      }
+      return null;
+    }
+
+    // 独立图拓扑探索标签页
+    function initStandaloneGraph() {
+      document.getElementById('loadWholeGraphBtn').onclick = () => {
+        // TQL 边模式必须用匿名 -[]-> 语法（-[r]-> 会被解析器拒绝并返回 400）；
+        // MATCH 投影无法返回边对象，改由 renderGraph 按行内节点出现顺序推断连线
+        setEditorValue('MATCH (a)-[]->(b) RETURN a, b LIMIT 100');
+        document.querySelector('[data-tab="queryPane"]').click();
+        document.querySelector('[data-view="graph"]').click();
+        executeCurrentQuery();
+      };
+    }
+
+    // ==========================================
+    // 教程系统控制器
+    // ==========================================
+    function setupTutorial() {
+      const overlay = document.getElementById('tutorialOverlay');
+      const openBtn = document.getElementById('openTutorialBtn');
+      const closeBtn = document.getElementById('closeTutorialBtn');
+      const nav = document.getElementById('tutorialStepsNav');
+
+      openBtn.addEventListener('click', () => overlay.classList.add('open'));
+      closeBtn.addEventListener('click', () => overlay.classList.remove('open'));
+      overlay.addEventListener('click', (e) => {
+        if (e.target === overlay) overlay.classList.remove('open');
+      });
+
+      // 渲染步骤列表
+      nav.innerHTML = '';
+      TUTORIAL_STEPS.forEach((step, idx) => {
+        const item = document.createElement('div');
+        item.className = `tutorial-step-item ${idx === 0 ? 'active' : ''}`;
+        item.innerHTML = `<span>${step.title}</span>`;
+        item.addEventListener('click', () => {
+          document.querySelectorAll('.tutorial-step-item').forEach(i => i.classList.remove('active'));
+          item.classList.add('active');
+          renderTutorialContent(step);
+        });
+        nav.appendChild(item);
+      });
+
+      renderTutorialContent(TUTORIAL_STEPS[0]);
+    }
+
+    function renderTutorialContent(step) {
+      const pane = document.getElementById('tutorialContentPane');
+      pane.innerHTML = step.desc;
+    }
+
+    window.runTutorialCode = function(code, isMutation, targetTab = 'grid') {
+      setEditorValue(code);
+      document.getElementById('mutationCheck').checked = !!isMutation;
+      document.getElementById('tutorialOverlay').classList.remove('open');
+
+      if (targetTab === 'graph') {
+        document.querySelector('[data-view="graph"]').click();
+      } else {
+        document.querySelector('[data-view="grid"]').click();
+      }
+      executeCurrentQuery();
+    };
+
+    window.initTutorialData = async function() {
+      // 链式创建：一次语句同时建立节点与 AUTHORED / COVERS 图关系，
+      // 保证第 3 关（图匹配）与第 5 关（混合管线）开箱可查
+      const statements = [
+        'CREATE ({name: "Alice", type: "person", citations: 150, department: "AI Lab"})-[:AUTHORED]->({title: "TriviumDB Architecture", type: "paper", year: 2026})-[:COVERS]->({name: "Tri-Model DB", type: "topic"})',
+        'CREATE ({name: "Bob", type: "person", citations: 45, department: "Systems"})-[:AUTHORED]->({title: "QuIVer Vector Engine", type: "paper", year: 2025})-[:COVERS]->({name: "Tri-Model DB", type: "topic"})',
+        'CREATE ({name: "Carol", type: "person", citations: 210, department: "AI Lab"})'
+      ];
+      showToast('正在注入教学数据集...');
+      let succeeded = 0;
+      for (const query of statements) {
+        try {
+          const res = await fetch(`${API_BASE}/v1/tql`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ query, mutation: true })
+          });
+          if (res.ok) succeeded++;
+        } catch (_) {}
+      }
+      showToast(
+        succeeded === statements.length
+          ? `注入完成（${succeeded} 条语句），可直接运行第 2 / 3 关的查询`
+          : `注入完成 ${succeeded}/${statements.length}，部分语句失败请查看服务端日志`,
+        3200
+      );
+      checkServerHealth();
+    };
+
+    // ==========================================
+    // TQL 语法高亮（叠加层方案：pre 与 textarea 文本对齐，textarea 文字透明仅露光标）
+    // 关键词主色加粗 / 字符串琥珀 / 数字青 / 注释灰
+    // ==========================================
+    const TQL_KEYWORDS = [
+      'EXPLAIN', 'ANALYZE', 'FIND', 'MATCH', 'SEARCH', 'VECTOR', 'WHERE', 'RETURN',
+      'WITH', 'LIMIT', 'CREATE', 'LINK', 'DELETE', 'AND', 'OR', 'TOP',
+      'ORDER', 'BY', 'ASC', 'DESC', 'SET'
+    ];
+
+    function highlightTql(text) {
+      const esc = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      const re = new RegExp(
+        '(\\/\\/[^\\n]*|#[^\\n]*)' +            // 1: 注释
+        '|("(?:[^"\\\\]|\\\\.)*")' +            // 2: 字符串（支持 \" 转义）
+        '|(-?\\d+(?:\\.\\d+)?)' +               // 3: 数字
+        '|\\b(' + TQL_KEYWORDS.join('|') + ')\\b', // 4: 关键词
+        'gi'
+      );
+      let out = '';
+      let last = 0;
+      let m;
+      while ((m = re.exec(text)) !== null) {
+        out += esc(text.slice(last, m.index));
+        if (m[1] !== undefined) out += `<span class="tk-comment">${esc(m[1])}</span>`;
+        else if (m[2] !== undefined) out += `<span class="tk-string">${esc(m[2])}</span>`;
+        else if (m[3] !== undefined) out += `<span class="tk-number">${esc(m[3])}</span>`;
+        else out += `<span class="tk-keyword">${esc(m[4])}</span>`;
+        last = m.index + m[0].length;
+        if (m[0].length === 0) re.lastIndex += 1; // 空匹配保护
+      }
+      out += esc(text.slice(last));
+      return out;
+    }
+
+    function updateTqlHighlight() {
+      const area = document.getElementById('tqlInput');
+      const pre = document.getElementById('tqlHighlight');
+      if (!area || !pre) return;
+      // 尾部补换行：保证 pre 与 textarea 的滚动高度一致（textarea 末行下方有缓冲）
+      pre.innerHTML = highlightTql(area.value) + '\n';
+      pre.scrollTop = area.scrollTop;
+      pre.scrollLeft = area.scrollLeft;
+    }
+
+    // 统一编辑器赋值入口：程序化 .value 赋值不触发 input 事件，必须手动同步高亮
+    function setEditorValue(value) {
+      document.getElementById('tqlInput').value = value;
+      updateTqlHighlight();
+    }
+
+    // ==========================================
+    // 命令面板 (Ctrl/Cmd + K)
+    // 数据源：侧栏代码片段(data-snippet) / 快速动作(data-action) / 查询历史 /
+    //        主题切换 / 美化 TQL / 清空编辑器 / 导出 JSON / 打开教程 / 切换标签
+    // 交互：子序列模糊匹配（命中字符高亮）、↑↓ 选择 + Enter 执行、鼠标点击执行、
+    //        空查询按分组显示全部、无结果显示「无匹配命令」、focus trap + Esc 关闭、
+    //        reduced-motion / 无 GSAP 时无动画
+    // ==========================================
+    const paletteState = { items: [], filtered: [], active: -1 };
+
+    function buildPaletteItems() {
+      const items = [];
+      document.querySelectorAll('[data-snippet]').forEach((el) => {
+        const nameEl = el.querySelector('span');
+        items.push({
+          group: '代码片段',
+          label: (nameEl ? nameEl.textContent + ' — ' : '') + el.dataset.snippet,
+          keywords: el.dataset.snippet,
+          run: () => el.click()
+        });
+      });
+      document.querySelectorAll('[data-action]').forEach((el) => {
+        const nameEl = el.querySelector('span');
+        items.push({
+          group: '快速动作',
+          label: nameEl ? nameEl.textContent : el.dataset.action,
+          keywords: el.dataset.action,
+          run: () => el.click()
+        });
+      });
+      queryHistory.slice(0, 10).forEach((q) => {
+        items.push({
+          group: '查询历史',
+          label: q,
+          run: () => {
+            setEditorValue(q);
+            executeCurrentQuery();
+          }
+        });
+      });
+      items.push(
+        { group: '操作', label: '切换主题 (深色/浅色)', run: () => document.getElementById('themeToggleBtn').click() },
+        { group: '操作', label: '美化 TQL', run: () => formatTql() },
+        { group: '操作', label: '清空编辑器', run: () => document.getElementById('clearEditorBtn').click() },
+        { group: '操作', label: '导出 JSON 结果', run: () => exportJson() },
+        { group: '操作', label: '打开可视化教程', run: () => document.getElementById('openTutorialBtn').click() },
+        { group: '导航', label: '切换到 TQL 查询控制台', run: () => document.querySelector('[data-tab="queryPane"]').click() },
+        { group: '导航', label: '切换到独立图拓扑探索', run: () => document.querySelector('[data-tab="graphExplorePane"]').click() },
+        { group: '导航', label: '切换到向量检索 (Vector Lab)', run: () => document.querySelector('[data-tab="vectorLabPane"]').click() }
+      );
+      return items;
+    }
+
+    // 子序列模糊匹配：按顺序消费 query 字符，返回命中下标数组（用于高亮），不匹配返回 null
+    function subsequenceMatch(query, text) {
+      const q = query.toLowerCase();
+      const t = text.toLowerCase();
+      const idxs = [];
+      let i = 0;
+      for (let j = 0; j < t.length && i < q.length; j++) {
+        if (t[j] === q[i]) { idxs.push(j); i += 1; }
+      }
+      return i === q.length ? idxs : null;
+    }
+
+    function paletteEntryText(entry) {
+      // 空查询下高亮为 null；搜索时优先标签命中，其次 keywords 命中（无高亮）
+      return entry.hit || null;
+    }
+
+    function renderPaletteList() {
+      const list = document.getElementById('paletteList');
+      const query = document.getElementById('paletteInput').value.trim();
+      list.innerHTML = '';
+      paletteState.filtered = [];
+
+      paletteState.items.forEach((item) => {
+        if (query) {
+          let hit = subsequenceMatch(query, item.label);
+          if (!hit) {
+            // 标签未命中时回退 keywords 命中（无 keywords 或 keywords 也未命中则排除）
+            if (!item.keywords || !subsequenceMatch(query, item.keywords)) return;
+          }
+          paletteState.filtered.push({ item, hit });
+        } else {
+          paletteState.filtered.push({ item, hit: null });
+        }
+      });
+
+      if (!paletteState.filtered.length) {
+        const empty = document.createElement('div');
+        empty.className = 'palette-empty';
+        empty.textContent = '无匹配命令';
+        list.appendChild(empty);
+      } else {
+        let lastGroup = null;
+        paletteState.filtered.forEach((entry, idx) => {
+          if (entry.item.group !== lastGroup) {
+            const g = document.createElement('div');
+            g.className = 'palette-group';
+            g.textContent = entry.item.group;
+            list.appendChild(g);
+            lastGroup = entry.item.group;
+          }
+          list.appendChild(buildPaletteItemEl(entry, idx));
+        });
+      }
+
+      paletteState.active = paletteState.filtered.length ? 0 : -1;
+      applyActivePaletteItem();
+    }
+
+    function buildPaletteItemEl(entry, idx) {
+      const el = document.createElement('div');
+      el.className = 'palette-item';
+      el.id = `palette-opt-${idx}`;
+      el.setAttribute('role', 'option');
+      el.dataset.index = String(idx);
+      const labelSpan = document.createElement('span');
+      const hit = paletteEntryText(entry);
+      if (hit) {
+        let last = 0;
+        hit.forEach((i) => {
+          if (i > last) labelSpan.appendChild(document.createTextNode(entry.item.label.slice(last, i)));
+          const mark = document.createElement('mark');
+          mark.textContent = entry.item.label[i];
+          labelSpan.appendChild(mark);
+          last = i + 1;
+        });
+        labelSpan.appendChild(document.createTextNode(entry.item.label.slice(last)));
+      } else {
+        labelSpan.textContent = entry.item.label;
+      }
+      el.appendChild(labelSpan);
+      const kind = document.createElement('span');
+      kind.className = 'pi-kind';
+      kind.textContent = entry.item.group;
+      el.appendChild(kind);
+      el.addEventListener('click', () => executePaletteItem(paletteState.filtered[idx]));
+      el.addEventListener('mousemove', () => applyActivePaletteItem(idx));
+      return el;
+    }
+
+    function applyActivePaletteItem() {
+      const list = document.getElementById('paletteList');
+      const input = document.getElementById('paletteInput');
+      const els = list.querySelectorAll('.palette-item');
+      els.forEach((el, i) => {
+        const active = i === paletteState.active;
+        el.classList.toggle('active', active);
+        el.setAttribute('aria-selected', String(active));
+        if (active) {
+          input.setAttribute('aria-activedescendant', el.id);
+          el.scrollIntoView({ block: 'nearest' });
+        }
+      });
+      if (paletteState.active === -1) input.removeAttribute('aria-activedescendant');
+    }
+
+    function movePaletteActive(delta) {
+      if (!paletteState.filtered.length) return;
+      const next = (paletteState.active + delta + paletteState.filtered.length) % paletteState.filtered.length;
+      paletteState.active = next;
+      applyActivePaletteItem();
+    }
+
+    function executePaletteItem(entry) {
+      closePalette();
+      if (entry && entry.item && typeof entry.item.run === 'function') entry.item.run();
+    }
+
+    function openPalette() {
+      const overlay = document.getElementById('paletteOverlay');
+      const input = document.getElementById('paletteInput');
+      overlay.classList.add('open');
+      input.value = '';
+      paletteState.items = buildPaletteItems(); // 打开时重建，保证查询历史最新
+      renderPaletteList();
+      input.focus();
+      if (window.gsap && !prefersReducedMotion()) {
+        gsap.fromTo('.palette',
+          { opacity: 0, y: -8 },
+          { opacity: 1, y: 0, duration: 0.16, ease: 'power2.out', overwrite: true, clearProps: 'opacity,transform' }
+        );
+      }
+    }
+
+    function closePalette() {
+      const overlay = document.getElementById('paletteOverlay');
+      overlay.classList.remove('open');
+      document.getElementById('paletteInput').value = '';
+    }
+
+    function setupPalette() {
+      const overlay = document.getElementById('paletteOverlay');
+      const input = document.getElementById('paletteInput');
+
+      // 全局快捷键：Ctrl/Cmd + K 呼出/关闭，Esc 关闭
+      document.addEventListener('keydown', (e) => {
+        const isOpen = overlay.classList.contains('open');
+        if ((e.ctrlKey || e.metaKey) && (e.key === 'k' || e.key === 'K')) {
+          e.preventDefault();
+          if (isOpen) closePalette(); else openPalette();
+        } else if (isOpen && e.key === 'Escape') {
+          e.preventDefault();
+          closePalette();
+        }
+      });
+
+      // 输入过滤 + 键盘导航（focus trap：面板内仅 input 可聚焦，Tab 拦截）
+      input.addEventListener('input', renderPaletteList);
+      input.addEventListener('keydown', (e) => {
+        if (e.key === 'ArrowDown') { e.preventDefault(); movePaletteActive(1); }
+        else if (e.key === 'ArrowUp') { e.preventDefault(); movePaletteActive(-1); }
+        else if (e.key === 'Enter') {
+          e.preventDefault();
+          if (paletteState.active >= 0) executePaletteItem(paletteState.filtered[paletteState.active]);
+        } else if (e.key === 'Tab') {
+          e.preventDefault();
+        }
+      });
+
+      // 点击遮罩关闭
+      overlay.addEventListener('click', (e) => {
+        if (e.target === overlay) closePalette();
+      });
+    }
+
+    // ==========================================
+    // 实用工具 (格式化 / 导出 / 历史)
+    // ==========================================
+    function formatTql() {
+      const area = document.getElementById('tqlInput');
+      let text = area.value;
+      const keywords = ['FIND', 'MATCH', 'SEARCH', 'VECTOR', 'TOP', 'WHERE', 'RETURN', 'WITH', 'LIMIT', 'CREATE', 'LINK', 'DELETE', 'AND', 'OR'];
+      keywords.forEach(kw => {
+        const reg = new RegExp(`\\b${kw}\\b`, 'gi');
+        text = text.replace(reg, kw);
+      });
+      setEditorValue(text);
+    }
+
+    function exportJson() {
+      if (!currentResultData) {
+        alert('当前没有可导出的结果');
+        return;
+      }
+      const blob = new Blob([JSON.stringify(currentResultData, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `triviumdb-export-${Date.now()}.json`;
+      a.click();
+    }
+
+    function saveHistory(q) {
+      if (!queryHistory.includes(q)) {
+        queryHistory.unshift(q);
+        if (queryHistory.length > 30) queryHistory.pop();
+        localStorage.setItem('tdb_query_history', JSON.stringify(queryHistory));
+        renderHistory();
+      }
+    }
+
+    function renderHistory() {
+      const container = document.getElementById('historyList');
+      if (!queryHistory.length) return;
+      container.innerHTML = '';
+      queryHistory.slice(0, 10).forEach(q => {
+        const item = document.createElement('div');
+        item.className = 'nav-item';
+        item.style.fontSize = '11px';
+        item.style.padding = '5px 14px';
+        item.innerHTML = `<span style="overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">${q}</span>`;
+        item.onclick = () => {
+          setEditorValue(q);
+          executeCurrentQuery();
+        };
+        container.appendChild(item);
+      });
+    }
+  </script>
+  <script>
+    // ==========================================
+    // 页内自检套件 (In-page Selftest) —— 仅当 URL 带 ?selftest=1 时启用。
+    // 零依赖 vanilla JS，集中在本 IIFE：
+    //   1) fetch mock 层：拦截全部 API 调用返回固定 fixture（离线可测、结果确定）；
+    //   2) 命名断言集：覆盖主题/标签页/渲染管线/mutation/错误/向量校验/节点抽屉/力导向收敛；
+    //   3) 顶部固定结果条：N passed / M failed，每条断言可展开详情，结束后 console.table 摘要。
+    // 正常模式（无参数）下 IIFE 第一行即返回：不安装拦截器、不注入 DOM，零开销。
+    // 阶段 2 的命令面板断言通过 window.__selftestRegister 扩展点在同一轮补齐。
+    // ==========================================
+    (function () {
+      'use strict';
+      if (!new URLSearchParams(window.location.search).get('selftest')) return;
+      if (window.__TRIVIUM_SELFTEST__) return;
+      window.__TRIVIUM_SELFTEST__ = true;
+
+      // ---------- 结果条样式（JS 注入，避免污染正常模式 CSS） ----------
+      const style = document.createElement('style');
+      style.textContent = [
+        'body.selftest-running { padding-top: 36px; }',
+        '#selftestBar { position: fixed; top: 0; left: 0; right: 0; z-index: 9999;',
+        '  display: flex; align-items: center; gap: 12px; padding: 6px 14px;',
+        '  background: var(--bg-surface); border-bottom: 2px solid var(--border-focus);',
+        '  font-family: var(--font-sans); font-size: 12px; box-shadow: var(--shadow-md); }',
+        '#selftestBar .st-pass { color: var(--success); font-weight: 600; }',
+        '#selftestBar .st-fail { color: var(--danger); font-weight: 600; }',
+        '#selftestDetails { position: fixed; top: 34px; left: 0; right: 0; z-index: 9999;',
+        '  max-height: 45vh; overflow: auto; padding: 8px 14px;',
+        '  background: var(--bg-surface); border-bottom: 1px solid var(--border-color);',
+        '  box-shadow: var(--shadow-md); font-family: var(--font-sans); font-size: 12px; }',
+        '#selftestDetails details { margin: 3px 0; }',
+        '#selftestDetails summary { cursor: pointer; font-family: var(--font-mono); font-size: 11.5px; }',
+        '#selftestDetails .st-group { color: var(--text-light); margin-left: 6px; }',
+        '#selftestDetails .st-err { color: var(--danger); font-family: var(--font-mono); font-size: 11px;',
+        '  white-space: pre-wrap; padding: 4px 0 6px 20px; }'
+      ].join('\n');
+      document.head.appendChild(style);
+
+      // ---------- fetch mock 层（fixture 形状与后端 protocol.rs encode_node/encode_rows 对齐） ----------
+      const NODE_ALICE = { type: 'node', id: '1', payload: { name: 'Alice', type: 'person', citations: 150, department: 'AI Lab' }, vector: [0.1, 0.2, 0.3, 0.4], edges: [] };
+      const NODE_BOB = { type: 'node', id: '2', payload: { name: 'Bob', type: 'person', citations: 45, department: 'Systems' }, vector: [0.5, 0.4, 0.3, 0.2], edges: [] };
+      const NODE_PAPER = { type: 'node', id: '3', payload: { title: 'TriviumDB Architecture', type: 'paper', year: 2026 }, vector: [0.9, 0.8, 0.7, 0.6], edges: [] };
+      const FIND_ROWS = [{ node: NODE_ALICE }, { node: NODE_BOB }, { node: NODE_PAPER }];
+      const MATCH_ROWS = [{ a: NODE_ALICE, b: NODE_BOB }, { a: NODE_BOB, b: NODE_PAPER }];
+      const GEN = 'gen-selftest';
+      const jsonRes = (body, status) => new Response(JSON.stringify(body), {
+        status: status || 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+
+      // ---------- NDJSON 流式 mock（PR-11）：模拟服务端流式响应 ----------
+      const NDJSON_CT = { 'Content-Type': 'application/x-ndjson; charset=utf-8' };
+      // 定长切块故意不与行边界对齐：单行 JSON 被拆进多个 chunk，验证跨 chunk 残行拼接
+      function ndjsonRes(lines, chunkSize) {
+        const enc = new TextEncoder();
+        const size = chunkSize || 64;
+        const payload = lines.map(l => JSON.stringify(l) + '\n').join('');
+        const chunks = [];
+        for (let i = 0; i < payload.length; i += size) chunks.push(payload.slice(i, i + size));
+        let sent = 0;
+        return new Response(new ReadableStream({
+          pull(controller) {
+            if (sent < chunks.length) controller.enqueue(enc.encode(chunks[sent++]));
+            else controller.close();
+          }
+        }), { status: 200, headers: NDJSON_CT });
+      }
+      // 可控放行的流：start 发出前 headCount 个事件后暂停，release 时一次性 enqueue 余下事件并关闭。
+      // 不依赖 pull 协议（pull 中不 enqueue 会导致读取端挂起行为因引擎实现而异），
+      // 直接持有 controller 引用主动推送 —— 行为确定，用于验证「流未结束已渲染首批」。
+      window.__ndjsonGate = { released: false, release() { window.__ndjsonGate.released = true; } };
+      function gatedNdjsonRes(lines, headCount) {
+        const enc = new TextEncoder();
+        const head = headCount || 1;
+        let controllerRef = null;
+        window.__ndjsonGate.release = () => {
+          window.__ndjsonGate.released = true;
+          if (!controllerRef) return;
+          for (let i = head; i < lines.length; i++) {
+            controllerRef.enqueue(enc.encode(JSON.stringify(lines[i]) + '\n'));
+          }
+          controllerRef.close();
+        };
+        return new Response(new ReadableStream({
+          start(controller) {
+            controllerRef = controller;
+            // 首个 chunk：meta + 前 head-1 行一次性发出，之后暂停等待放行
+            controller.enqueue(enc.encode(lines.slice(0, head).map(l => JSON.stringify(l) + '\n').join('')));
+          },
+          // 未放行时显式挂起 pull（永不 resolve 的 promise）：部分引擎（WebKit）对
+          // start-only 流会在队列耗尽后提前结束读取，导致「流未结束」语义失效
+          pull() {
+            return window.__ndjsonGate.released ? undefined : new Promise(() => {});
+          }
+        }), { status: 200, headers: NDJSON_CT });
+      }
+      // NDJSON 事件行组装：meta → row* → summary（与后端 query_response 的流式形状一致）
+      const metaLine = { type: 'meta', generation: GEN };
+      const summaryLine = (n) => ({ type: 'summary', rowCount: n, profile: { totalMicros: 1234, executionMicros: 900 }, indexAdvice: [] });
+      const rowLines = (rows) => rows.map(r => ({ type: 'row', row: r }));
+
+      window.fetch = async function (input, init) {
+        const url = typeof input === 'string' ? input : (input && input.url) || '';
+        const path = url.replace(/^https?:\/\/[^/]+/, '');
+        if (path.indexOf('/health/ready') === 0) return jsonRes({ status: 'ok', version: '9.9.9-selftest' });
+        if (path.indexOf('/health/details') === 0) {
+          return jsonRes({ status: 'ready', writeQueueDepth: 0, writeQueueCapacity: 256, activeReads: 0, quiverWarmup: 'ready' });
+        }
+        if (path.indexOf('/v1/tql') === 0) {
+          let req = {};
+          try { req = JSON.parse((init && init.body) || '{}'); } catch (_) {}
+          const q = String(req.query || '');
+          const h = (init && init.headers) || {};
+          const accept = String(h['Accept'] || h['accept'] || '');
+          // 自检观测点：请求头快照（验证 mutation 不携带 NDJSON Accept）
+          window.__lastTqlObserved = { accept, mutation: !!req.mutation, query: q };
+          if (req.mutation) return jsonRes({ rows: [], row_count: 0, affected: 1, createdIds: ['901'], generation: GEN });
+          // 强制 JSON 400：验证非流式错误体走 renderError 兜底
+          if (q.indexOf('FORCE_ERROR') === 0) return jsonRes({ title: '流式兜底错误', detail: 'SELFTEST_FORCE_400' }, 400);
+          // 行集合按查询语义选择（与 JSON mock 一致）
+          let rows;
+          if (q.indexOf('MATCH') === 0) rows = MATCH_ROWS;
+          else if (q.indexOf('SEARCH') === 0) rows = [{ hit: NODE_ALICE, score: { type: 'float', value: 0.98 } }];
+          else rows = FIND_ROWS;
+          // 特殊流式 fixture（NDJSON 自检专用）
+          if (q.indexOf('EMPTY_STREAM') === 0) {
+            return ndjsonRes([metaLine, summaryLine(0)]);
+          }
+          if (q.indexOf('STREAM_ERR') === 0) {
+            const errRows = [{ node: { type: 'node', id: '81', payload: { name: 'StreamA', type: 'person' }, vector: [] } },
+              { node: { type: 'node', id: '82', payload: { name: 'StreamE1', type: 'person' }, vector: [] } },
+              { node: { type: 'node', id: '83', payload: { name: 'StreamE2', type: 'person' }, vector: [] } }];
+            const errLine = { type: 'error', detail: 'SELFTEST_STREAM_ERROR row encoding failed' };
+            return ndjsonRes([metaLine, rowLines([errRows[0]])[0], errLine, rowLines([errRows[1]])[0], rowLines([errRows[2]])[0], summaryLine(3)]);
+          }
+          if (q.indexOf('GATED_STREAM') === 0) {
+            const gateRows = FIND_ROWS.concat([
+              { node: { type: 'node', id: '91', payload: { name: 'StreamG4', type: 'person' }, vector: [] } },
+              { node: { type: 'node', id: '92', payload: { name: 'StreamG5', type: 'person' }, vector: [] } }
+            ]);
+            const errLine = { type: 'error', detail: 'SELFTEST_GATED_ERROR' };
+            const lines = [metaLine, ...rowLines(gateRows.slice(0, 3)), errLine, ...rowLines(gateRows.slice(3)), summaryLine(5)];
+            window.__ndjsonGate.released = false;
+            // 首个 chunk 发 meta + 3 行后暂停：验证「流未结束首批已渲染」
+            return gatedNdjsonRes(lines, 4);
+          }
+          if (q.indexOf('GATED_BIG_STREAM') === 0) {
+            // 600 行大流：meta + 210 行（>虚拟阈值 200，先迁移虚拟窗口）后暂停，
+            // release 后补 390 行 + summary —— 验证流式迁移、视口保持与钉底跟随
+            const bigRows = Array.from({ length: 600 }, (_, i) => (
+              { node: { type: 'node', id: String(1000 + i), payload: { name: 'V' + i, type: 'person' }, vector: [] } }
+            ));
+            window.__ndjsonGate.released = false;
+            return gatedNdjsonRes([metaLine, ...rowLines(bigRows), summaryLine(600)], 211);
+          }
+          // 无 NDJSON Accept：走旧 JSON 形状（Vector Lab 候选加载等内部调用不带 Accept）
+          const wantsNdjson = accept.split(',').some(s => s.trim() === 'application/x-ndjson');
+          if (!wantsNdjson) {
+            return jsonRes({ rows, row_count: rows.length, generation: GEN });
+          }
+          return ndjsonRes([metaLine, ...rowLines(rows), summaryLine(rows.length)]);
+        }
+        const nodeMatch = path.match(/^\/v1\/nodes\/([^/?]+)/);
+        if (nodeMatch) {
+          const id = nodeMatch[1];
+          const node = id === '1' ? NODE_ALICE : (id === '2' ? NODE_BOB : NODE_PAPER);
+          return jsonRes({ node, edgeVersions: id === '1' ? [{ targetId: '2', label: 'KNOWS', version: 1 }] : [] });
+        }
+        if (path.indexOf('/v1/search/vector') === 0) {
+          return jsonRes({ hits: [{ id: '1', score: 0.98, payload: NODE_ALICE.payload }], generation: GEN });
+        }
+        return jsonRes({ title: 'SELFTEST_MOCK_MISS', detail: path }, 404);
+      };
+
+      // ---------- 断言注册表与结果条 ----------
+      const suite = [];
+      function addAssert(name, group, fn) { suite.push({ name, group, fn, status: 'pending', error: null }); }
+      // 扩展点：阶段 2 命令面板等后续功能的断言经此注入，与内置断言同一轮执行
+      window.__selftestRegister = addAssert;
+
+      const assert = (cond, msg) => { if (!cond) throw new Error(msg || 'assertion failed'); };
+      const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+      async function waitFor(fn, timeout, label) {
+        const deadline = Date.now() + (timeout || 3000);
+        while (Date.now() < deadline) {
+          try { const v = fn(); if (v) return v; } catch (_) {}
+          await sleep(50);
+        }
+        throw new Error('waitFor 超时: ' + (label || '条件未满足'));
+      }
+
+      // 结果条 DOM
+      const bar = document.createElement('div');
+      bar.id = 'selftestBar';
+      bar.setAttribute('role', 'status');
+      bar.innerHTML = '<strong>Selftest</strong><span id="selftestSummary">准备中...</span>' +
+        '<button type="button" class="btn" id="selftestDetailsBtn" aria-expanded="false">详情</button>';
+      document.body.classList.add('selftest-running');
+      document.body.insertBefore(bar, document.body.firstChild);
+      const detailsBox = document.createElement('div');
+      detailsBox.id = 'selftestDetails';
+      detailsBox.hidden = true;
+      document.body.insertBefore(detailsBox, bar.nextSibling);
+      document.getElementById('selftestDetailsBtn').addEventListener('click', () => {
+        detailsBox.hidden = !detailsBox.hidden;
+        document.getElementById('selftestDetailsBtn').setAttribute('aria-expanded', String(!detailsBox.hidden));
+      });
+
+      function renderBar() {
+        const passed = suite.filter(i => i.status === 'pass').length;
+        const failed = suite.filter(i => i.status === 'fail').length;
+        const done = passed + failed === suite.length;
+        document.getElementById('selftestSummary').innerHTML =
+          '<span class="st-pass">' + passed + ' passed</span> / ' +
+          '<span class="st-fail">' + failed + ' failed</span>' +
+          (done ? '' : ' / 运行中 ' + (suite.length - passed - failed));
+        detailsBox.innerHTML = suite.map(item =>
+          '<details' + (item.status === 'fail' ? ' open' : '') + '><summary>' +
+          (item.status === 'pass' ? '✅' : item.status === 'fail' ? '❌' : '⏳') +
+          ' ' + item.name + '<span class="st-group">[' + item.group + ']</span></summary>' +
+          (item.error ? '<div class="st-err">' + item.error + '</div>' : '') +
+          '</details>'
+        ).join('');
+      }
+
+      // ---------- 内置断言集 ----------
+      // 自检基建
+      addAssert('fetch mock 生效：/health/ready 驱动连接徽章', '自检基建', async () => {
+        await waitFor(() => document.getElementById('connText').textContent.indexOf('在线') === 0, 3000, '连接徽章应显示在线');
+      });
+
+      // 主题
+      addAssert('主题切换：light→dark→light 并持久化到 localStorage', '主题', async () => {
+        document.documentElement.setAttribute('data-theme', 'light');
+        localStorage.setItem('tdb_theme', 'light');
+        document.getElementById('themeToggleBtn').click();
+        assert(document.documentElement.getAttribute('data-theme') === 'dark', '第一次点击后应为 dark');
+        assert(localStorage.getItem('tdb_theme') === 'dark', 'localStorage 应记录 dark');
+        document.getElementById('themeToggleBtn').click();
+        assert(document.documentElement.getAttribute('data-theme') === 'light', '第二次点击应回到 light');
+        assert(localStorage.getItem('tdb_theme') === 'light', 'localStorage 应记录 light');
+      });
+
+      // 标签页
+      addAssert('标签页切换：三个主标签互斥激活', '标签页', async () => {
+        document.querySelector('[data-tab="vectorLabPane"]').click();
+        assert(document.getElementById('vectorLabPane').classList.contains('active'), 'vectorLabPane 应激活');
+        assert(!document.getElementById('queryPane').classList.contains('active'), 'queryPane 应失活');
+        document.querySelector('[data-tab="graphExplorePane"]').click();
+        assert(document.getElementById('graphExplorePane').classList.contains('active'), 'graphExplorePane 应激活');
+        document.querySelector('[data-tab="queryPane"]').click();
+        assert(document.getElementById('queryPane').classList.contains('active'), 'queryPane 应恢复激活');
+      });
+
+      addAssert('结果视图切换：grid/graph/json 三视图互斥', '标签页', async () => {
+        document.querySelector('[data-view="json"]').click();
+        assert(document.getElementById('viewJson').style.display === 'block', 'json 视图应显示');
+        assert(document.getElementById('viewGrid').style.display === 'none', 'grid 视图应隐藏');
+        document.querySelector('[data-view="grid"]').click();
+        assert(document.getElementById('viewGrid').style.display === 'block', 'grid 视图应恢复');
+      });
+
+      // 渲染管线
+      addAssert('renderGrid：列数/行数/单元格内容', '渲染管线', async () => {
+        renderGrid(FIND_ROWS);
+        const headCols = document.getElementById('gridHead').querySelectorAll('th').length;
+        assert(headCols === 2, '应有 2 列 (# + node)，实际 ' + headCols);
+        const rows = document.getElementById('gridBody').querySelectorAll('tr');
+        assert(rows.length === FIND_ROWS.length, '应有 ' + FIND_ROWS.length + ' 行，实际 ' + rows.length);
+        assert(rows[0].textContent.indexOf('Alice') !== -1, '首行应包含 Alice');
+        renderGrid([]);
+        assert(document.getElementById('gridBody').textContent.indexOf('没有匹配的行') !== -1, '空结果应显示占位文案');
+        renderGrid(FIND_ROWS);
+      });
+
+      addAssert('renderGrid：节点行携带可点击 360° 入口', '渲染管线', async () => {
+        const clickable = document.querySelectorAll('#gridBody tr.row-clickable');
+        assert(clickable.length === FIND_ROWS.length, '所有节点行应可点击，实际 ' + clickable.length);
+        assert(clickable[0].getAttribute('role') === 'button' && clickable[0].tabIndex === 0, '节点行应键盘可达 (role=button + tabIndex)');
+      });
+
+      addAssert('mutation 结果渲染：受影响行数与 createdIds', '渲染管线', async () => {
+        renderMutationResult({ affected: 2, createdIds: ['901', '902'], generation: GEN });
+        const body = document.getElementById('gridBody').textContent;
+        assert(body.indexOf('写入成功') !== -1, '应显示写入成功');
+        assert(body.indexOf('901') !== -1 && body.indexOf('902') !== -1, '应显示两个 createdIds');
+        const treeText = document.getElementById('rawJsonOutput').textContent;
+        assert(treeText.includes('affected') && treeText.includes('901'), 'JSON 树应反映 mutation 数据');
+        assert(document.querySelector('#rawJsonOutput .jt-toggle'), 'JSON 树应可折叠');
+      });
+
+      addAssert('错误渲染：标题/详情同时呈现在表格与 JSON 视图', '渲染管线', async () => {
+        renderError({ title: '自检注入错误', detail: 'detail-xyz' });
+        const body = document.getElementById('gridBody').textContent;
+        assert(body.indexOf('自检注入错误') !== -1 && body.indexOf('detail-xyz') !== -1, '错误标题与详情应呈现');
+        assert(document.getElementById('rawJsonOutput').textContent.includes('自检注入错误'), 'JSON 树应承载错误对象');
+      });
+
+      addAssert('JSON 树：类型着色与计数徽标', '渲染管线', async () => {
+        renderRawJson({ str: 'abc', num: 1.5, bool: true, nul: null, arr: [1, 2], obj: { x: 1 } });
+        const root = document.getElementById('rawJsonOutput');
+        assert(root.querySelector('.jt-val-string'), '字符串值应有类型 span');
+        assert(root.querySelector('.jt-val-number'), '数字值应有类型 span');
+        assert(root.querySelector('.jt-val-bool'), '布尔值应有类型 span');
+        assert(root.querySelector('.jt-val-null'), 'null 应有类型 span');
+        assert(root.querySelectorAll('.jt-badge').length >= 2, '对象/数组应有计数徽标');
+      });
+
+      addAssert('JSON 树：默认展开 2 层、点击可折叠', '渲染管线', async () => {
+        renderRawJson({ a: { b: { c: 1 } } });
+        const root = document.getElementById('rawJsonOutput');
+        const toggles = root.querySelectorAll('.jt-toggle');
+        assert(toggles.length === 3, '三层嵌套对象应有 3 个折叠按钮，实际 ' + toggles.length);
+        const expanded = Array.from(toggles).filter(t => t.getAttribute('aria-expanded') === 'true').length;
+        assert(expanded === 2, '默认应展开前 2 层，实际展开 ' + expanded);
+        toggles[0].click();
+        assert(toggles[0].getAttribute('aria-expanded') === 'false', '点击后 aria-expanded 应变 false');
+        assert(root.querySelector('.jt-children.collapsed'), '点击后子层应隐藏');
+        toggles[0].click();
+      });
+
+      // 向量实验台
+      addAssert('向量实验台：非法 JSON 报「JSON 解析失败」', '向量实验台', async () => {
+        switchVectorSource(false);
+        document.getElementById('vlJsonInput').value = '{not json';
+        let err = null;
+        try { resolveQueryVector(); } catch (e) { err = e; }
+        assert(err && err.title === 'JSON 解析失败', '应抛出 JSON 解析失败，实际 ' + (err && err.title));
+      });
+
+      addAssert('向量实验台：维度不匹配报「维度不匹配」', '向量实验台', async () => {
+        vlKnownDim = 4;
+        document.getElementById('vlJsonInput').value = '[0.1, 0.2]';
+        let err = null;
+        try { resolveQueryVector(); } catch (e) { err = e; }
+        vlKnownDim = null;
+        assert(err && err.title === '维度不匹配', '应抛出维度不匹配，实际 ' + (err && err.title));
+      });
+
+      addAssert('向量实验台：无向量节点报「节点无向量」', '向量实验台', async () => {
+        switchVectorSource(true);
+        vlCandidates = [{ id: '7', payload: { name: 'NoVec' } }];
+        const select = document.getElementById('vlNodeSelect');
+        select.innerHTML = '<option value="0">#7 NoVec</option>';
+        select.value = '0';
+        let err = null;
+        try { resolveQueryVector(); } catch (e) { err = e; }
+        vlCandidates = [];
+        assert(err && err.title === '节点无向量', '应抛出节点无向量，实际 ' + (err && err.title));
+      });
+
+      addAssert('向量实验台：mock 检索流水线渲染 hits 表格', '向量实验台', async () => {
+        switchVectorSource(false);
+        vlKnownDim = 4;
+        document.getElementById('vlJsonInput').value = '[0.1, 0.2, 0.3, 0.4]';
+        await runVectorSearch();
+        vlKnownDim = null;
+        switchVectorSource(true);
+        assert(!document.getElementById('vlResultTable').hidden, '结果表格应显示');
+        assert(!document.getElementById('vlPipeline').hidden, '流水线条应显示');
+        assert(document.getElementById('vlPipelineHits').textContent === '1', 'hits 计数应为 1');
+        assert(document.getElementById('vlResultBody').children.length === 1, '应渲染 1 行命中');
+      });
+
+      addAssert('score 比例条：单条命中为满条', '向量实验台', async () => {
+        // 复用上一条 mock 检索的单 hit 结果：归一化后比例条应为满宽
+        const bar = document.querySelector('#vlResultBody .score-bar i');
+        assert(bar, 'score 单元格应含比例条');
+        assert(bar.style.width === '100%', '单条命中比例条应 100%，实际 ' + bar.style.width);
+      });
+
+      // 节点抽屉
+      addAssert('节点抽屉：Trinity 三平面渲染 (Payload/Vector/Edges)', '节点抽屉', async () => {
+        openNodeDrawer({ id: '1', label: 'Alice', payload: NODE_ALICE.payload, vector: NODE_ALICE.vector });
+        assert(document.getElementById('nodeDrawer').classList.contains('open'), '抽屉应打开');
+        const payloadText = document.getElementById('drawerNodePayload').textContent;
+        assert(payloadText.includes('Alice') && payloadText.includes('citations'), 'Payload 平面应承载 JSON payload');
+        assert(document.getElementById('drawerNodeVector').textContent.indexOf('dim = 4') !== -1, 'Vector 平面应显示维度');
+        await waitFor(() => document.querySelector('#drawerNodeEdges .inspector-edge-item'), 3000, '边列表应加载');
+        assert(document.getElementById('drawerNodeEdges').textContent.indexOf('KNOWS') !== -1, '边标签应显示');
+      });
+
+      addAssert('节点抽屉：边跳转到目标节点后重渲染', '节点抽屉', async () => {
+        document.querySelector('#drawerNodeEdges .inspector-edge-target').click();
+        await waitFor(() => document.getElementById('drawerNodeTitle').textContent.indexOf('#2') !== -1, 3000, '标题应跳到 #2');
+        assert(document.getElementById('drawerNodePayload').textContent.includes('Bob'), '跳转后 Payload 应为 Bob');
+        document.getElementById('closeDrawerBtn').click();
+        assert(!document.getElementById('nodeDrawer').classList.contains('open'), '关闭按钮应收起抽屉');
+      });
+
+      addAssert('向量热力条：抽屉色块、tooltip 与 L2 摘要', '节点抽屉', async () => {
+        renderDrawerVector([0, 0.25, 0.5, 1]);
+        const container = document.getElementById('drawerNodeVector');
+        const cells = container.querySelectorAll('.heat-strip i');
+        assert(cells.length === 4, '应有 4 个色块，实际 ' + cells.length);
+        assert(cells[0].style.background !== cells[3].style.background, '首尾色块颜色应不同');
+        assert(cells[0].title === 'dim 0: 0.0000' && cells[3].title === 'dim 3: 1.0000', 'tooltip 应含维度与数值');
+        assert(container.textContent.includes('dim = 4') && container.textContent.includes('L2'), '应显示 dim 与 L2 范数');
+        assert(container.querySelector('details'), '精确数值应折叠在 details');
+        renderDrawerVector(NODE_ALICE.vector); // 恢复抽屉向量平面状态
+      });
+
+      // 力导向收敛
+      addAssert('力导向收敛：400 tick 后节点无重叠且在界内', '力导向', async () => {
+        document.querySelector('[data-view="graph"]').click();
+        redrawGraph(); // 同步完成画布尺寸同步（父容器此刻可见）
+        const canvas = document.getElementById('graphCanvas');
+        assert(canvas.width > 0 && canvas.height > 0, '画布应有非零尺寸');
+        renderGraph(MATCH_ROWS);
+        simulationRunning = false; // 停掉 rAF 循环，改为确定性手动 tick
+        assert(graphNodes.length === 3, '应有 3 个节点，实际 ' + graphNodes.length);
+        assert(graphEdges.length >= 2, '至少应推断出 2 条边，实际 ' + graphEdges.length);
+        const halfW = canvas.width / 2 - 70;
+        const halfH = canvas.height / 2 - 70;
+        for (let i = 0; i < 400; i++) { simulationAlpha = 0.6; tickPhysics(); }
+        simulationAlpha = 0.005;
+        for (let i = 0; i < graphNodes.length; i++) {
+          for (let j = i + 1; j < graphNodes.length; j++) {
+            const d = Math.hypot(graphNodes[i].x - graphNodes[j].x, graphNodes[i].y - graphNodes[j].y);
+            assert(d > 40, '节点 ' + i + ' 与 ' + j + ' 重叠: dist=' + d.toFixed(1));
+          }
+          const n = graphNodes[i];
+          assert(Math.abs(n.x) <= halfW + 50 && Math.abs(n.y) <= halfH + 50,
+            '节点 ' + i + ' 越界: (' + n.x.toFixed(0) + ', ' + n.y.toFixed(0) + ')');
+        }
+        document.querySelector('[data-view="grid"]').click();
+      });
+
+      // 死按钮回归修复
+      addAssert('死按钮修复：加载全图拓扑用合法语法出图', '回归修复', async () => {
+        const before = currentResultData;
+        document.getElementById('loadWholeGraphBtn').click();
+        await waitFor(() => currentResultData && currentResultData !== before, 3000, '查询应完成');
+        assert(document.getElementById('tqlInput').value === 'MATCH (a)-[]->(b) RETURN a, b LIMIT 100',
+          '应使用 -[]-> 合法语法');
+        assert(document.getElementById('viewGraph').style.display === 'block', '应切换到图视图');
+        assert((currentResultData.rows || []).length === 2, '应返回 2 行');
+        await waitFor(() => graphNodes.length === 3, 3000, '图节点应渲染');
+      });
+
+      // ---------- 边界加固（PR-10）：XSS / 深嵌套 / 大数组 / 万行网格 / 图规模护栏 ----------
+      const mkBoundaryNode = (id, name) => ({ type: 'node', id: String(id), payload: { name, type: 'person' }, vector: [] });
+
+      addAssert('XSS 防护：payload 含 img onerror / script 均以文本渲染', '边界加固', async () => {
+        window.__xssHit = false;
+        const evil = '<img src=x onerror="window.__xssHit=true">';
+        renderGrid([{ node: mkBoundaryNode('x1', evil) }]);
+        const body = document.getElementById('gridBody');
+        assert(!body.querySelector('img'), '网格不应注入 img 元素');
+        assert(!body.querySelector('script'), '网格不应注入 script 元素');
+        assert(body.textContent.includes('<img src=x'), '恶意串应以文本呈现');
+        assert(window.__xssHit === false, 'onerror 处理器不应被执行');
+        renderRawJson({ s: '<script>window.__xssJsonHit = 1<\/script>' });
+        const jsonRoot = document.getElementById('rawJsonOutput');
+        assert(!jsonRoot.querySelector('script'), 'JSON 树不应注入 script 元素');
+        assert(jsonRoot.textContent.includes('<script>'), 'JSON 树中 script 字样应以文本呈现');
+        assert(window.__xssJsonHit === undefined, 'JSON 树中的脚本不应执行');
+        renderGrid(FIND_ROWS); // 还原网格状态
+      });
+
+      addAssert('JSON 树：40 层深嵌套可渲染、带省略标记并可逐层展开', '边界加固', async () => {
+        let deep = { v: 0 };
+        for (let i = 1; i <= 40; i++) deep = { n: deep };
+        renderRawJson(deep);
+        const root = document.getElementById('rawJsonOutput');
+        // 懒渲染：首屏只构建默认展开的前几层 DOM，深层节点不存在（防一次性全量构建）
+        assert(root.querySelectorAll('.jt-toggle').length === 3,
+          '首屏应只构建 3 层折叠按钮（懒渲染），实际 ' + root.querySelectorAll('.jt-toggle').length);
+        // 逐层展开：点击当前最深的折叠按钮，每次只构建下一层
+        for (let i = 0; i < 40 && root.querySelectorAll('.jt-toggle').length < 40; i++) {
+          const ts = root.querySelectorAll('.jt-toggle');
+          ts[ts.length - 1].click();
+        }
+        const toggles = root.querySelectorAll('.jt-toggle');
+        assert(toggles.length === 40, '逐层展开后应有 40 个折叠按钮，实际 ' + toggles.length);
+        assert(root.querySelector('.jt-deep-marker'), '超过 20 层的层级应显示省略标记');
+        assert(root.textContent.includes('更深'), '标记应含「更深」文案');
+        // 最深层节点默认折叠且子 DOM 懒构建（仅占位闭合行），点击后只展开一层
+        const deepest = toggles[toggles.length - 1];
+        const deepestWrap = deepest.parentElement.parentElement;
+        const deepestKids = deepestWrap.querySelector('.jt-children');
+        assert(deepestKids.children.length === 1, '未展开的深层节点子 DOM 应懒构建，实际 ' + deepestKids.children.length);
+        deepest.click();
+        assert(deepestKids.children.length === 2, '展开后应构建下一层子节点');
+        assert(deepest.getAttribute('aria-expanded') === 'true', '展开后 aria-expanded 应为 true');
+      });
+
+      addAssert('JSON 树：10000 元素数组懒渲染，首屏 DOM 受限且展开可用', '边界加固', async () => {
+        renderRawJson({ big: Array.from({ length: 10000 }, (_, i) => i) });
+        const root = document.getElementById('rawJsonOutput');
+        const before = root.querySelectorAll('.jt-line').length;
+        assert(before < 300, '首屏 DOM 行数应受限（懒渲染），实际 ' + before);
+        const badge = Array.from(root.querySelectorAll('.jt-badge')).find(b => b.textContent.includes('10000'));
+        assert(badge, '应显示 10000 items 计数徽标');
+        badge.parentElement.querySelector('.jt-toggle').click();
+        await waitFor(() => root.querySelectorAll('.jt-line').length >= 10001, 3000, '展开后应构建全部元素');
+        // 再次点击应收起（折叠回去），验证大数组展开后可折叠
+        badge.parentElement.querySelector('.jt-toggle').click();
+        assert(root.querySelector('.jt-children.collapsed'), '再次点击后大数组子层应折叠');
+      });
+
+      addAssert('虚拟滑窗：10000 行窗口化渲染（tbody < 100 行）+ spacer 总高一致 + 固定行高列宽', '虚拟滑窗', async () => {
+        document.querySelector('[data-view="grid"]').click();
+        const bigRows = Array.from({ length: 10000 }, (_, i) => ({ node: mkBoundaryNode(i + 1, 'N' + (i + 1)) }));
+        const t0 = performance.now();
+        renderGrid(bigRows);
+        await waitFor(() => document.querySelectorAll('#gridBody tr:not(.virtual-spacer)').length > 10, 3000, '窗口行应渲染');
+        const elapsed = performance.now() - t0;
+        assert(elapsed < 1500, '万行窗口化渲染应 < 1500ms，实际 ' + elapsed.toFixed(0) + 'ms');
+        // 窗口化证据：数据 10000 行，DOM 实际行数（含 2 个 spacer）必须远小于数据量
+        const trs = document.querySelectorAll('#gridBody tr');
+        assert(trs.length < 100, 'tbody 实际行数应 < 100（窗口化），实际 ' + trs.length);
+        const table = document.getElementById('gridTable');
+        assert(table.classList.contains('virtual-grid'), '应带 virtual-grid 类（table-layout:fixed）');
+        assert(table.querySelector('colgroup col'), '应有 colgroup 显式列宽策略');
+        // spacer 总高 + 窗口行 = 数据总高（换算行距一致，无漂移）
+        const spacerTds = document.querySelectorAll('#gridBody tr.virtual-spacer td');
+        const rowH = gridVirtual.rowH();
+        const topH = parseFloat(spacerTds[0].style.height);
+        const bottomH = parseFloat(spacerTds[1].style.height);
+        const totalH = topH + bottomH + (trs.length - 2) * rowH;
+        assert(Math.abs(totalH - 10000 * rowH) < rowH,
+          'spacer+窗口总高应等于数据总高，实际 ' + totalH.toFixed(1) + ' vs ' + (10000 * rowH));
+        assert(document.querySelector('#gridBody tr[data-row-index="0"]').textContent.includes('N1'), '首行应包含 N1');
+        // 实测行距应接近 CSS 目标 32px（±2px 容差，含 border-collapse 影响）
+        assert(Math.abs(rowH - 32) <= 2, '实测行距应 ≈ 32px，实际 ' + rowH);
+        // 行数上限提示条仍由 10000 行触发（与流式路径语义一致）
+        assert(!document.getElementById('rowLimitNotice').hidden, '万行数据应触发行数上限提示');
+        // 提示条可关闭（原「行数上限」断言随万行测试就地校验，避免依赖测试间状态残留）
+        const noticeEl = document.getElementById('rowLimitNotice');
+        assert(noticeEl.textContent.includes('10000') && noticeEl.textContent.includes('LIMIT'), '提示应含上限 10000 与 LIMIT 建议');
+        noticeEl.querySelector('.result-notice-close').click();
+        assert(noticeEl.hidden, '点击关闭后提示条应隐藏');
+      });
+
+      addAssert('虚拟滑窗：滚动到中部后窗口行号/内容正确，回顶还原', '虚拟滑窗', async () => {
+        // 复用上一条断言的 10000 行虚拟网格
+        const container = document.getElementById('viewGrid');
+        // 滚动到「数据第 5000 行」的内容位置（contentTop 为 tbody 首行流内偏移）
+        const spacer = document.querySelector('#gridBody tr.virtual-spacer');
+        const contentTop = spacer.getBoundingClientRect().top
+          - container.getBoundingClientRect().top + container.scrollTop;
+        container.scrollTop = contentTop + gridVirtual.rowH() * 5000;
+        container.dispatchEvent(new Event('scroll'));
+        await waitFor(() => {
+          const tr = document.querySelector('#gridBody tr[data-row-index="5000"]');
+          return tr && tr.children[0].textContent === '5001';
+        }, 3000, '滚动后第 5000 行应渲染且行号为 5001');
+        const mid = document.querySelector('#gridBody tr[data-row-index="5000"]');
+        assert(mid.textContent.includes('N5001'), '第 5000 行应包含 N5001');
+        // 回顶还原
+        container.scrollTop = 0;
+        container.dispatchEvent(new Event('scroll'));
+        await waitFor(() => document.querySelector('#gridBody tr[data-row-index="0"]'), 3000, '回顶后首行应渲染');
+      });
+
+      addAssert('虚拟滑窗：tbody 事件委托 — 窗口内行点击打开 360° 抽屉', '虚拟滑窗', async () => {
+        const tr = document.querySelector('#gridBody tr[data-row-index="3"]');
+        assert(tr && tr.classList.contains('row-clickable'), '节点行应可点击');
+        tr.click();
+        assert(document.getElementById('nodeDrawer').classList.contains('open'), '点击虚拟行应经委托打开抽屉');
+        assert(document.getElementById('drawerNodePayload').textContent.includes('N4'), '抽屉应显示第 4 行节点的 Payload');
+        document.getElementById('closeDrawerBtn').click();
+        assert(!document.getElementById('nodeDrawer').classList.contains('open'), '抽屉应关闭');
+      });
+
+      addAssert('虚拟滑窗：键盘导航 — 焦点行 ArrowDown 跨窗口滚动跟随', '虚拟滑窗', async () => {
+        const first = document.querySelector('#gridBody tr[data-row-index="0"]');
+        first.focus();
+        assert(document.activeElement === first, '首行应可聚焦');
+        // 连续 ArrowDown 60 次：窗口（约 20-40 行）必然滑动，焦点应始终跟随到新窗口内的行
+        for (let i = 0; i < 60; i++) {
+          const cur = document.activeElement;
+          if (!cur || !cur.dataset || cur.dataset.rowIndex === undefined) break;
+          cur.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }));
+        }
+        await waitFor(() => document.querySelector('#gridBody tr[data-row-index="60"]'), 3000, '第 60 行应因窗口滑动而渲染');
+        const focused = document.querySelector('#gridBody tr[data-row-index="60"]');
+        assert(document.activeElement === focused, '焦点应跟随到第 60 行');
+        // 焦点行应滚入可视区
+        const container = document.getElementById('viewGrid');
+        const cRect = container.getBoundingClientRect();
+        const top = focused.getBoundingClientRect().top;
+        assert(top >= cRect.top && top < cRect.bottom, '焦点行应在可视区内 (top=' + (top - cRect.top).toFixed(0) + ')');
+      });
+
+      addAssert('虚拟滑窗：阈值以下（150 行）仍全量渲染且委托行为一致', '虚拟滑窗', async () => {
+        const small = Array.from({ length: 150 }, (_, i) => ({ node: mkBoundaryNode(i + 1, 'S' + (i + 1)) }));
+        renderGrid(small);
+        assert(!document.getElementById('gridTable').classList.contains('virtual-grid'), '150 行不应启用虚拟滑窗');
+        assert(document.querySelectorAll('#gridBody tr').length === 150, '应全量渲染 150 行');
+        assert(document.querySelector('#gridBody tr[data-row-index="149"]').textContent.includes('S150'), '末行内容正确');
+        document.querySelector('#gridBody tr[data-row-index="0"]').click();
+        assert(document.getElementById('nodeDrawer').classList.contains('open'), '委托点击应打开抽屉');
+        document.getElementById('closeDrawerBtn').click();
+      });
+
+      addAssert('虚拟滑窗：流式迁移 — 大流式结果切虚拟窗口且视口位置保持', '虚拟滑窗', async () => {
+        setEditorValue('GATED_BIG_STREAM RETURN *');
+        const done = executeCurrentQuery();
+        // 首 chunk：meta + 210 行 → 超过阈值迁移为虚拟窗口
+        await waitFor(() => document.getElementById('statusRowCount').textContent === '返回: 210 行', 3000, '暂停点前应已渲染 210 行');
+        assert(gridVirtual, '超过阈值后应迁移为虚拟滑窗');
+        assert(document.querySelectorAll('#gridBody tr').length < 60, '虚拟窗口下 DOM 行数应远小于 210');
+        const container = document.getElementById('viewGrid');
+        assert(container.scrollTop === 0, '流式增长时顶部视口应保持');
+        window.__ndjsonGate.release();
+        await done;
+        await waitFor(() => (currentResultData.rows || []).length === 600, 3000, '放行后应收到全部 600 行');
+        assert(container.scrollTop === 0, '不在底部时视口位置应保持（不跟随增长）');
+        // 回归守护：非钉底追加期间 bottom spacer 必须随 total 刷新
+        // （曾因 syncWindow 窗口未变 early-return 固化在迁移时刻，滚动范围停在 200 行）
+        const spacerTr = document.querySelector('#gridBody tr.virtual-spacer');
+        const cTop = spacerTr.getBoundingClientRect().top
+          - container.getBoundingClientRect().top + container.scrollTop;
+        const expectTotal = cTop + 600 * gridVirtual.rowH();
+        assert(Math.abs(container.scrollHeight - expectTotal) <= gridVirtual.rowH(),
+          '流结束后滚动范围应覆盖全部 600 行，实际 scrollHeight=' + container.scrollHeight + ' 期望≈' + expectTotal);
+      });
+
+      addAssert('虚拟滑窗：流式底部跟随 — 用户钉在底部时自动跟随增长', '虚拟滑窗', async () => {
+        setEditorValue('GATED_BIG_STREAM RETURN *');
+        const done = executeCurrentQuery();
+        await waitFor(() => document.getElementById('statusRowCount').textContent === '返回: 210 行', 3000, '暂停点前应已渲染 210 行');
+        const container = document.getElementById('viewGrid');
+        // 钉在底部后放行：增长应自动跟随
+        container.scrollTop = container.scrollHeight;
+        window.__ndjsonGate.release();
+        await done;
+        await waitFor(() => (currentResultData.rows || []).length === 600, 3000, '放行后应收到全部 600 行');
+        await waitFor(() => document.querySelector('#gridBody tr[data-row-index="599"]'), 3000, '末行应在窗口内渲染');
+        const atBottom = container.scrollTop + container.clientHeight >= container.scrollHeight - gridVirtual.rowH() * 2;
+        assert(atBottom, '钉底时流式增长应自动跟随');
+        renderGrid(FIND_ROWS); // 还原非虚拟状态
+      });
+
+      addAssert('虚拟滑窗：连续往返滚动不产生孤儿行（DOM 行数有界、spacer 一致）', '虚拟滑窗', async () => {
+        // 回归守护：窗口滑出行必须从 DOM 移除（曾因孤儿行累积导致内容高度漂移）
+        const bigRows = Array.from({ length: 10000 }, (_, i) => ({ node: mkBoundaryNode(i + 1, 'N' + (i + 1)) }));
+        renderGrid(bigRows);
+        await waitFor(() => document.querySelectorAll('#gridBody tr:not(.virtual-spacer)').length > 10, 3000, '窗口行应渲染');
+        const container = document.getElementById('viewGrid');
+        for (let i = 0; i < 12; i++) {
+          container.scrollTop = (i % 2 === 0) ? gridVirtual.rowH() * 3000 : gridVirtual.rowH() * 100;
+          container.dispatchEvent(new Event('scroll'));
+          // 等两帧：让 rAF 节流的窗口重算真实执行，往返间窗口滑出/滑入各发生一次
+          await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+        }
+        await waitFor(() => document.querySelector('#gridBody tr[data-row-index="100"]'), 3000, '窗口应对齐最后一次滚动位置');
+        const trCount = document.querySelectorAll('#gridBody tr').length;
+        assert(trCount < 100, '往返滚动后 DOM 行数应有界（无孤儿行累积），实际 ' + trCount);
+        assert(document.querySelectorAll('#gridBody tr.virtual-spacer').length === 2, 'spacer 应恒为 2 个');
+        // top spacer 与最终滚动位置一致（contentTop 实测，含提示条/sticky 表头偏移）
+        const spacerTr = document.querySelector('#gridBody tr.virtual-spacer');
+        const contentTop = spacerTr.getBoundingClientRect().top
+          - container.getBoundingClientRect().top + container.scrollTop;
+        const expectedStart = Math.max(0, Math.floor((container.scrollTop - contentTop) / gridVirtual.rowH()) - 5);
+        const topH = parseFloat(spacerTr.querySelector('td').style.height);
+        assert(topH === expectedStart * gridVirtual.rowH(),
+          'top spacer 应与最终滚动位置一致，实际 ' + topH + ' 期望 ' + expectedStart * gridVirtual.rowH());
+        renderGrid(FIND_ROWS); // 还原
+      });
+
+      addAssert('图护栏：700 节点自动暂停力学并显示提示条', '边界加固', async () => {
+        const rows700 = Array.from({ length: 700 }, (_, i) => ({ n: mkBoundaryNode(i + 1, 'G' + (i + 1)) }));
+        simulationRunning = true; // 先置为可模拟，证明 renderGraph 会因规模自动关闭
+        renderGraph(rows700);
+        assert(graphNodes.length === 700, '应渲染 700 节点，实际 ' + graphNodes.length);
+        assert(simulationRunning === false, '超过 300 节点应自动关闭物理模拟');
+        assert(document.getElementById('togglePhysicsBtn').textContent === '恢复力学', '冻结按钮应显示「恢复力学」');
+        const notice = document.getElementById('graphScaleNotice');
+        assert(notice && !notice.hidden, '应显示规模提示条');
+        assert(notice.textContent.includes('300') && notice.textContent.includes('力学'), '提示应说明暂停力学原因');
+        notice.querySelector('.result-notice-close').click();
+        assert(notice.hidden, '提示条应可关闭');
+      });
+
+      addAssert('图护栏：1600 节点只渲染前 1500 且提示总数', '边界加固', async () => {
+        const rows1600 = Array.from({ length: 1600 }, (_, i) => ({ n: mkBoundaryNode(i + 1, 'G' + (i + 1)) }));
+        renderGraph(rows1600);
+        assert(graphNodes.length === 1500, '应只渲染 1500 节点，实际 ' + graphNodes.length);
+        const notice = document.getElementById('graphScaleNotice');
+        assert(notice && !notice.hidden, '应显示截断提示条');
+        assert(notice.textContent.includes('仅渲染前 1500'), '提示应含「仅渲染前 1500」，实际: ' + notice.textContent);
+        assert(notice.textContent.includes('1600'), '提示应含真实总节点数 1600');
+      });
+
+      addAssert('图护栏：规模禁用下点「恢复力学」仅提示不恢复，随后还原状态', '边界加固', async () => {
+        document.getElementById('togglePhysicsBtn').click();
+        assert(simulationRunning === false, '物理模拟不应被恢复');
+        await waitFor(() => document.querySelector('#toastStack .toast'), 2000, '应出现不支持恢复的 toast 提示');
+        // 还原常规小结果状态，避免影响后续/人工检查
+        renderGrid(FIND_ROWS);
+        renderGraph(MATCH_ROWS);
+      });
+
+      // ---------- WebGL 图渲染（PR-13）：CDN 按需加载 / 后端切换 / 社区着色 / 离线降级 ----------
+      // fake 库：graphology.Graph / Sigma / louvain 的最小实现（仅覆盖本 PR 用到的 API）
+      class FakeGraph {
+        constructor() { this._nodes = new Map(); this._edges = []; this._edgeKeys = new Set(); }
+        addNode(id, attrs) { this._nodes.set(String(id), attrs || {}); }
+        addEdge(s, t, attrs) {
+          const k = String(s) + '|' + String(t);
+          if (!this._edgeKeys.has(k)) { this._edgeKeys.add(k); this._edges.push({ s: String(s), t: String(t), attrs: attrs || {} }); }
+        }
+        hasNode(id) { return this._nodes.has(String(id)); }
+        hasEdge(s, t) { return this._edgeKeys.has(String(s) + '|' + String(t)); }
+        setNodeAttribute(id, key, val) { if (this._nodes.has(String(id))) this._nodes.get(String(id))[key] = val; }
+        forEachNode(cb) { this._nodes.forEach((a, id) => cb(id, a)); }
+        order() { return this._nodes.size; }
+        size() { return this._edges.length; }
+      }
+      class FakeSigma {
+        constructor(graph, container, settings) {
+          FakeSigma.instances.push(this);
+          this.graph = graph;
+          this.container = container;
+          this.settings = settings || {};
+          this.handlers = {};
+          this.refreshCount = 0;
+          this.killed = false;
+        }
+        on(ev, cb) { (this.handlers[ev] = this.handlers[ev] || []).push(cb); }
+        refresh() { this.refreshCount++; }
+        kill() { this.killed = true; }
+        emit(ev, payload) { (this.handlers[ev] || []).forEach(cb => cb(payload)); }
+      }
+      FakeSigma.instances = [];
+      let fakeLouvainCalls = 0;
+      const origLoadScriptTag = loadScriptTag;
+      const origLoadCommunitiesModule = loadCommunitiesModule;
+      loadScriptTag = (src) => {
+        if (src.indexOf('graphology.umd') !== -1 && !window.graphology) {
+          window.graphology = { Graph: FakeGraph };
+        } else if (src.indexOf('sigma.min.js') !== -1 && !window.Sigma) {
+          window.Sigma = FakeSigma;
+        }
+        return Promise.resolve();
+      };
+      // louvain 走 ESM 动态 import，无法用 script 标签拦截 → 替换专用加载器
+      loadCommunitiesModule = async () => ({
+        louvain: (g) => {
+          fakeLouvainCalls++;
+          const out = {};
+          g._nodes.forEach((_, id) => { out[id] = 'C' + (Number(id) % 2); });
+          return out;
+        }
+      });
+
+      addAssert('WebGL 图渲染：CDN 按需加载 Sigma 成功并接管图视图', 'WebGL 图渲染', async () => {
+        document.querySelector('[data-view="graph"]').click();
+        renderGraph(MATCH_ROWS);
+        document.getElementById('toggleWebGLBtn').click();
+        await waitFor(() => graphBackend === 'sigma' && sigmaInstances.query, 3000, 'Sigma 实例应创建');
+        assert(sigmaInstances.query.graph.order() === 3, 'Sigma 图应有 3 节点，实际 ' + sigmaInstances.query.graph.order());
+        assert(sigmaInstances.query.graph.size() >= 2, 'Sigma 图应至少 2 边');
+        assert(!document.getElementById('graphSigmaContainer').hidden, 'Sigma 容器应显示');
+        assert(document.getElementById('toggleWebGLBtn').textContent === 'Canvas 渲染', '按钮应提示切回 Canvas');
+      });
+
+      addAssert('WebGL 图渲染：Sigma 节点点击打开 360° 抽屉', 'WebGL 图渲染', async () => {
+        sigmaInstances.query.sigma.emit('clickNode', { node: '1' });
+        assert(document.getElementById('nodeDrawer').classList.contains('open'), '点击 Sigma 节点应打开抽屉');
+        assert(document.getElementById('drawerNodeTitle').textContent.includes('Alice'), '抽屉应显示 Alice');
+        document.getElementById('closeDrawerBtn').click();
+        assert(!document.getElementById('nodeDrawer').classList.contains('open'), '抽屉应可关闭');
+      });
+
+      addAssert('WebGL 图渲染：Louvain 社区着色 + 图例，切回按类型还原', 'WebGL 图渲染', async () => {
+        document.getElementById('colorModeCommunityBtn').click();
+        await waitFor(() => graphColorMode === 'community' && nodeCommunities.size > 0, 3000, '社区检测应完成');
+        assert(!document.getElementById('graphLegend').hidden, '社区图例应显示');
+        assert(document.getElementById('graphLegend').querySelectorAll('.legend-chip').length >= 2, '图例应含社区条目');
+        assert(graphNodes.every(n => n.color !== getNodeColor(n.typeKey)), '所有节点应按社区重新着色');
+        document.getElementById('colorModeTypeBtn').click();
+        await waitFor(() => graphColorMode === 'type' && document.getElementById('graphLegend').hidden, 3000, '应切回按类型且图例隐藏');
+        assert(graphNodes.every(n => n.color === getNodeColor(n.typeKey)), '节点颜色应还原为类型色');
+        assert(document.getElementById('colorModeTypeBtnStandalone').classList.contains('active'),
+          '独立视图着色按钮应与全局状态同步');
+      });
+
+      addAssert('WebGL 图渲染：独立探索画布同一数据同一后端，加载全图拓扑路径不回归', 'WebGL 图渲染', async () => {
+        document.querySelector('[data-tab="graphExplorePane"]').click();
+        assert(sigmaInstances.standalone, '独立画布 Sigma 实例应存在（后端全局共享）');
+        assert(sigmaInstances.standalone.graph.order() === 3, '独立画布应渲染同一图数据');
+        document.getElementById('loadWholeGraphBtn').click();
+        await waitFor(() => document.getElementById('tqlInput').value.indexOf('MATCH') === 0, 3000, '按钮应填充 MATCH 查询');
+        await waitFor(() => currentResultData && (currentResultData.rows || []).length === 2, 3000, '查询应完成并渲染 2 行');
+        assert(graphNodes.length === 3, '共享图数据应更新');
+      });
+
+      addAssert('WebGL 图渲染：CDN 加载失败回退 Canvas 并 toast 提示', 'WebGL 图渲染', async () => {
+        document.getElementById('toggleWebGLBtn').click(); // sigma -> canvas（同步路径）
+        assert(graphBackend === 'canvas', '应切回 Canvas');
+        assert(document.getElementById('graphSigmaContainer').hidden, '切回后 Sigma 容器应隐藏');
+        loadScriptTag = () => Promise.reject(new Error('offline'));
+        // 清空已缓存的库与全局：让 loadSigmaLibs 重新走（失败注入的）loader
+        sigmaLibs = null;
+        sigmaLoadPromise = null;
+        window.graphology = undefined;
+        window.Sigma = undefined;
+        document.getElementById('toggleWebGLBtn').click();
+        await waitFor(() => document.querySelector('#toastStack .toast'), 2000, '应出现回退 toast');
+        assert(graphBackend === 'canvas', '加载失败应保持 Canvas 渲染');
+        assert(document.getElementById('graphSigmaContainer').hidden, 'Sigma 容器应保持隐藏');
+        loadScriptTag = origLoadScriptTag; // 还原 loader
+        loadCommunitiesModule = origLoadCommunitiesModule;
+        renderGrid(FIND_ROWS); // 还原网格状态
+      });
+
+      // 语法高亮
+      addAssert('语法高亮：叠加层与 textarea 完全对齐（中文/换行/长行）', '渲染管线', async () => {
+        const area = document.getElementById('tqlInput');
+        const pre = document.getElementById('tqlHighlight');
+        area.value = 'MATCH (a)-[]->(b)\nWHERE a.name == "很长的中文内容测试对齐情况一二三四五六七八九十十一十二十三十四" RETURN a, b LIMIT 100 // 注释测试';
+        updateTqlHighlight();
+        assert(pre.scrollHeight === area.scrollHeight && pre.scrollWidth === area.scrollWidth,
+          `高亮层未对齐: pre ${pre.scrollWidth}x${pre.scrollHeight} vs area ${area.scrollWidth}x${area.scrollHeight}`);
+        assert(pre.querySelector('.tk-keyword'), '关键词应高亮');
+        assert(pre.querySelector('.tk-string'), '字符串应高亮');
+        assert(pre.querySelector('.tk-number'), '数字应高亮');
+        assert(pre.querySelector('.tk-comment'), '注释应高亮');
+        setEditorValue('FIND {type: "person"} RETURN * LIMIT 25');
+      });
+
+      // 命令面板
+      addAssert('命令面板：Ctrl+K 呼出、Esc 关闭', '命令面板', async () => {
+        const overlay = document.getElementById('paletteOverlay');
+        assert(!overlay.classList.contains('open'), '初始应关闭');
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
+        assert(overlay.classList.contains('open'), 'Ctrl+K 应呼出');
+        assert(document.activeElement === document.getElementById('paletteInput'), '呼出后搜索框应聚焦');
+        document.getElementById('paletteInput').dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+        assert(!overlay.classList.contains('open'), 'Esc 应关闭');
+      });
+
+      addAssert('命令面板：子序列搜索过滤 + 命中高亮', '命令面板', async () => {
+        document.getElementById('paletteOverlay').classList.remove('open'); // 确保从关闭态开始
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
+        const input = document.getElementById('paletteInput');
+        input.value = '主题';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        const items = document.querySelectorAll('#paletteList .palette-item');
+        assert(items.length === 1, `搜索「主题」应只剩主题命令，实际 ${items.length}`);
+        assert(items[0].textContent.includes('切换主题'), '应为主题命令');
+        assert(items[0].querySelector('mark'), '命中字符应高亮');
+        assert(items[0].getAttribute('role') === 'option', '列表项应为 option 角色');
+        document.getElementById('paletteInput').dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      });
+
+      addAssert('命令面板：Enter 键盘执行第一条（代码片段填充并运行）', '命令面板', async () => {
+        document.getElementById('paletteOverlay').classList.remove('open'); // 确保从关闭态开始
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
+        const input = document.getElementById('paletteInput');
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+        assert(!document.getElementById('paletteOverlay').classList.contains('open'), '执行后面板应关闭');
+        assert(document.getElementById('tqlInput').value === 'FIND {type: "person"} RETURN * LIMIT 20',
+          '第一条片段应填充编辑器，实际: ' + document.getElementById('tqlInput').value);
+        // 精确等待该片段的流式查询完整落地（此前 indexOf('返回:')===0 会被前序测试
+        // 遗留的 '返回: 600 行' 立即满足，fire-and-forget 查询跨界污染后续断言）
+        await waitFor(() => document.getElementById('statusRowCount').textContent === '返回: 3 行'
+          && currentResultData && currentResultData.rows && currentResultData.rows.length === 3,
+        3000, '片段应已执行且流式结果完整落地');
+      });
+
+      addAssert('命令面板：主题切换命令生效', '命令面板', async () => {
+        document.getElementById('paletteOverlay').classList.remove('open'); // 确保从关闭态开始
+        document.documentElement.setAttribute('data-theme', 'light');
+        localStorage.setItem('tdb_theme', 'light');
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
+        const input = document.getElementById('paletteInput');
+        input.value = '主题';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+        assert(document.documentElement.getAttribute('data-theme') === 'dark', '主题命令应切到 dark');
+        assert(localStorage.getItem('tdb_theme') === 'dark', '主题命令应持久化');
+        document.getElementById('themeToggleBtn').click(); // 还原 light
+      });
+
+      // ---------- NDJSON 流式（PR-11）：流式解析/批量渲染/错误兜底/结果完整性 ----------
+      addAssert('NDJSON 流式：mutation 请求不携带 NDJSON Accept 且仍走 JSON 渲染', 'NDJSON 流式', async () => {
+        document.getElementById('mutationCheck').checked = true;
+        document.getElementById('tqlInput').value = 'CREATE ({name: "StreamMut"})';
+        await executeCurrentQuery();
+        document.getElementById('mutationCheck').checked = false;
+        const obs = window.__lastTqlObserved;
+        assert(obs && obs.mutation === true, '观测点应记录 mutation 请求');
+        assert(obs.accept.indexOf('application/x-ndjson') === -1, 'mutation 不应携带 NDJSON Accept，实际: ' + obs.accept);
+        assert(document.getElementById('gridBody').textContent.indexOf('写入成功') !== -1, 'mutation 应保持 JSON 渲染路径');
+      });
+
+      addAssert('NDJSON 流式：首行早现（流未结束已渲染首批）且行计数递增', 'NDJSON 流式', async () => {
+        setEditorValue('GATED_STREAM FIND {type: "person"} RETURN *');
+        const before = currentResultData;
+        const done = executeCurrentQuery();
+        // 闸门流在 meta + 3 行后暂停：此刻流未结束，首批必须已经渲染
+        await waitFor(() => document.getElementById('statusRowCount').textContent === '返回: 3 行', 3000, '暂停点前应已渲染 3 行');
+        // 失败现场诊断（PR-11 验收遗留：WebKit 冷启动偶发失败）：附带流状态与赋值点线索
+        assert(currentResultData === before,
+          '流未结束时 currentResultData 不应提前落地' +
+          ' [诊断: gate released=' + window.__ndjsonGate.released +
+          ', 状态栏=' + document.getElementById('statusRowCount').textContent +
+          ', 数据行=' + document.querySelectorAll('#gridBody tr[data-row-index]').length +
+          ', 全部tr=' + document.querySelectorAll('#gridBody tr').length +
+          ', 结果行数=' + (currentResultData && currentResultData.rows ? currentResultData.rows.length : 'n/a') + ']');
+        assert(document.querySelectorAll('#gridBody tr').length === 3, '首批 3 行应已进 DOM');
+        // 放行余下事件：error 行 + 2 行 + summary
+        window.__ndjsonGate.release();
+        await done;
+        await waitFor(() => (currentResultData.rows || []).length === 5, 3000, '放行后应收到全部 5 行');
+        assert(document.getElementById('gridBody').textContent.indexOf('StreamG5') !== -1, '末批行应渲染');
+        assert(document.getElementById('gridBody').textContent.indexOf('SELFTEST_GATED_ERROR') !== -1, '放行后的 error 行应内联显示');
+      });
+
+      addAssert('NDJSON 流式：跨 chunk 残行拼接 + meta/summary 落地（Generation/profile/indexAdvice）', 'NDJSON 流式', async () => {
+        setEditorValue('FIND {type: "person"} RETURN * LIMIT 25');
+        await executeCurrentQuery();
+        assert((currentResultData.rows || []).length === 3, '残行拼接后应得 3 行');
+        assert(document.getElementById('headerGeneration').textContent.indexOf(GEN) !== -1, 'meta 应更新 Generation 徽标');
+        assert(currentResultData.profile && currentResultData.indexAdvice, 'summary 应写入 profile/indexAdvice');
+        assert(currentResultData.rowCount === 3, 'summary.rowCount 应落地');
+        // JSON 树懒渲染：根/一层内容（generation/row_count）默认展开可见，深层 payload 需手动展开
+        assert(document.getElementById('rawJsonOutput').textContent.includes(GEN), 'JSON 树应承载流式最终结果 (generation)');
+        assert(document.getElementById('statusAffected').textContent === '只读', '只读查询应标记只读');
+      });
+
+      addAssert('NDJSON 流式：error 行不中断流，错误内联且后续行继续渲染', 'NDJSON 流式', async () => {
+        setEditorValue('STREAM_ERR FIND {type: "person"} RETURN *');
+        await executeCurrentQuery();
+        assert((currentResultData.rows || []).length === 3, 'error 行前后的数据行都应到达');
+        const body = document.getElementById('gridBody').textContent;
+        assert(body.indexOf('SELFTEST_STREAM_ERROR') !== -1, '行级错误应内联显示');
+        assert(body.indexOf('StreamE1') !== -1 && body.indexOf('StreamE2') !== -1, 'error 后续行应继续渲染');
+        assert((currentResultData.streamErrors || []).length === 1, 'streamErrors 应记录 1 条，实际 ' + (currentResultData.streamErrors || []).length);
+        assert(!document.querySelector('#gridBody img') && !document.querySelector('#gridBody script'), '错误行应文本渲染（XSS 安全）');
+      });
+
+      addAssert('NDJSON 流式：空流（仅 meta+summary rowCount 0）显示空态', 'NDJSON 流式', async () => {
+        setEditorValue('EMPTY_STREAM FIND {type: "ghost"} RETURN *');
+        await executeCurrentQuery();
+        assert(document.getElementById('gridBody').textContent.indexOf('没有匹配的行') !== -1, '空流应显示空结果占位');
+        assert((currentResultData.rows || []).length === 0, '空流 rows 应为 0');
+        assert(currentResultData.rowCount === 0, '空流 summary.rowCount 应为 0');
+        assert(document.getElementById('rowLimitNotice').hidden, '空流不应触发行数上限提示');
+      });
+
+      addAssert('NDJSON 流式：非 2xx JSON 错误体走 renderError 兜底', 'NDJSON 流式', async () => {
+        setEditorValue('FORCE_ERROR FIND {x: 1}');
+        await executeCurrentQuery();
+        const body = document.getElementById('gridBody').textContent;
+        assert(body.indexOf('流式兜底错误') !== -1 && body.indexOf('SELFTEST_FORCE_400') !== -1, '应渲染 JSON 错误体');
+        assert(document.getElementById('rawJsonOutput').textContent.includes('SELFTEST_FORCE_400'), '错误对象应进 JSON 视图');
+        renderGrid(FIND_ROWS); // 还原网格状态
+      });
+
+      addAssert('NDJSON 流式：currentResultData 形状完整可供导出（rows 全量 + generation + profile）', 'NDJSON 流式', async () => {
+        setEditorValue('FIND {type: "person"} RETURN * LIMIT 25');
+        await executeCurrentQuery();
+        assert(currentResultData, '流式查询后 currentResultData 应存在');
+        assert(Array.isArray(currentResultData.rows), 'rows 应为数组（导出全量行）');
+        assert(JSON.stringify(currentResultData).indexOf('"node"') !== -1, '导出对象应含完整行数据');
+        assert((currentResultData.streamErrors || []).length === 0, '正常流不应产生 streamErrors');
+        assert(currentResultData.generation === GEN, 'generation 应来自 meta 行');
+        // 批量 flush 观测：默认 3 行查询走 rAF flush，不应留下残余批次（行计数与 DOM 一致）
+        assert(document.querySelectorAll('#gridBody tr').length === 3, '行计数与 DOM 行数应一致');
+        renderGrid(FIND_ROWS);
+      });
+
+      // 命令面板（预留扩展点，阶段 2 补齐真实断言）
+      addAssert('扩展点就绪：__selftestRegister 可动态注入断言', '命令面板（预留）', async () => {
+        assert(typeof window.__selftestRegister === 'function', '应暴露 window.__selftestRegister');
+        window.__selftestRegister('扩展点自证：动态注册的断言被执行', '命令面板（预留）', async () => {
+          assert(document.title.indexOf('TriviumDB') !== -1, '动态断言应能访问页面环境');
+        });
+      });
+
+      // ---------- 执行器（支持运行中动态追加的断言） ----------
+      async function runSuite() {
+        renderBar();
+        let i = 0;
+        while (i < suite.length) {
+          const item = suite[i++];
+          item.status = 'running';
+          renderBar();
+          try {
+            // 未决流排空屏障：前序断言 fire-and-forget 的查询（如命令面板片段执行）
+            // 其迟到 flushBatch/落地可能跨界污染后续断言（webkit rAF 节流放大此窗口），
+            // 每条断言开始前先等 __activeQueryCount 归零
+            await waitFor(() => __activeQueryCount === 0, 10000, '前序未决流排空屏障');
+            await item.fn();
+            item.status = 'pass';
+          } catch (err) {
+            item.status = 'fail';
+            item.error = (err && err.message) ? err.message : String(err);
+          }
+          renderBar();
+        }
+        const failed = suite.filter(x => x.status === 'fail');
+        // eslint-disable-next-line no-console
+        console.table(suite.map(x => ({
+          group: x.group, name: x.name, status: x.status, error: x.error || ''
+        })));
+        // 供仓库冒烟脚本 (scripts/ui-smoke.mjs) 读取
+        window.__selftestResults = suite.map(x => ({ group: x.group, name: x.name, status: x.status, error: x.error }));
+        window.__selftestFailedCount = failed.length;
+        window.__selftestDone = true;
+      }
+
+      if (document.readyState === 'complete') runSuite();
+      else window.addEventListener('load', () => setTimeout(runSuite, 50));
+    })();
+  </script>
+  <script>
+    // 动效层：GSAP 按需从 CDN 加载；加载失败（如离线环境）时界面完整可用，仅退化为无动画。
+    document.addEventListener('DOMContentLoaded', () => {
+      if (window.gsap) { initMotion(); return; }
+      const script = document.createElement('script');
+      script.src = 'https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/gsap.min.js';
+      script.addEventListener('load', () => initMotion());
+      document.head.appendChild(script);
+    });
+  </script>
+</body>
+</html>

--- a/docs/server.md
+++ b/docs/server.md
@@ -109,6 +109,7 @@ RUST_LOG=triviumdb_server=info,triviumdb=warn ./triviumdb-server
 
 | 方法 | 路径 | 说明 |
 |---|---|---|
+| GET | `/` 或 `/ui` | 内置 Web Console 前端视窗（Navicat 风格三模管理与可视化教程） |
 | GET | `/health/live` | 纯事件循环存活探针，不获取 Database 锁 |
 | GET | `/health/ready` | Writer/read capacity 就绪状态；不可服务时返回 503 |
 | GET | `/health/details` | 脱敏运行状态、队列、读写等待和 QuIVer 预热状态 |


### PR DESCRIPTION
Adds a self-contained Web Console to the nightly server. This is the first of three stacked PRs that bring the WebUI work onto upstream dev: it carries the server route plus the console core, the second PR adds the graph-exploration/AI layer, and the third adds the test infrastructure.

Why the split: the complete WebUI is a single ~10.5k-line HTML file. One PR of that size cannot be reviewed. This PR stops at a point where the console is complete and useful on its own - query console with table/JSON/ graph result views, streaming NDJSON consumption, virtualized result grid, vector lab, node inspector, tutorial, command palette, Canvas graph view with the 300/1500 scale guardrails, and the WebGL/Sigma backend. The stacked PR builds the exploration layer on top of exactly this state.

Server side:
  - include_str! embeds web/index.html at compile time, so the binary has no runtime file dependency and no asset-path resolution to get wrong.
  - Cache-Control: no-cache, because the page is versioned together with the binary: after a server upgrade the browser must not keep serving the old UI against the new HTTP surface.
  - the contract test asserts 200 + text/html on both / and /ui plus two console-identifying strings, so the route cannot silently regress.

Invariants / compatibility / failure behavior / test evidence:
  - invariants: no Core semantics are touched. The console only consumes the existing public HTTP surface (POST /v1/tql, GET /v1/nodes/{id}, POST /v1/search/vector, /health/*). No new endpoint, no schema change, no new dependency.
  - compatibility: purely additive routes; / and /ui previously returned 404, so no existing client behavior changes.
  - failure behavior: serving the page is a read-only static response; no database handle is acquired, so the console stays reachable while the writer is unavailable (useful for diagnosing a degraded server).
  - test evidence: cargo test -p triviumdb-server passes including the new contract test; the page selftest suite (54 assertions at this stage) passes on chromium and webkit; end-to-end smoke against a real server covers the default query, the three result views, the 700-node scale guardrail, virtualized scrolling and the WebGL round trip.

Stacked on upstream/dev. The next PR in the stack
(feature/webui-explore-ai) is based on this branch and must be merged after it.

## 变更说明

<!-- 请用自己的话说明问题、实际修改和设计思路。不要只粘贴 AI 生成的摘要。 -->

### 解决的问题

解决TDB缺少WEB UI控制台的问题

### 实际修改

新增了WEB UI控制台

### 设计思路

现代化 间接性  可读性

## 高风险领域检查

<!-- 若涉及 WAL/事务/恢复、磁盘格式、mmap generation、Planner/预算、QuIVer/BQ/ANN 或三端公共 API，请填写以下四项；不涉及可写“不适用”。 -->

- **不变量：** 不适用
- **兼容性：** 不适用
- **故障行为：** 不适用
- **测试证据：** 不适用

## 提交前确认

- [✅️] PR 的目标分支是 `dev`。
- [✅️ ] 我已阅读 `CONTRIBUTING.md`。
- [✅️ ] 我已亲自阅读并理解最终变更，并在上方至少用自己的一句话作出说明。
- [✅️ ] 变更保持聚焦，没有包含无关重构或生成物。
- [ ✅️] 已补充或更新必要测试。
- [✅️ ] 已运行与本次变更相关的格式、Clippy、测试、存根及跨端检查。
- [ ✅️] 若修改公共 API，Rust、Python、Node、`.pyi`、`.d.ts` 与契约测试已同步。

---

## Change Description

<!-- Explain the problem, actual changes, and reasoning in your own words. Do not submit only an AI-generated summary. -->

### Problem solved


### Actual changes


### Reasoning


## High-risk area checks

<!-- If this PR touches WAL/transactions/recovery, disk formats, mmap generations, Planner/budgets, QuIVer/BQ/ANN, or public language APIs, complete all four items. Otherwise write “Not applicable.” -->

- **Invariants:**
- **Compatibility:**
- **Failure behavior:**
- **Test evidence:**

## Pre-submission checklist

- [ ] This PR targets `dev`.
- [ ] I have read `CONTRIBUTING.md`.
- [ ] I personally reviewed and understand the final change, and wrote at least one sentence above in my own words.
- [ ] The change is focused and contains no unrelated refactoring or generated artifacts.
- [ ] Necessary tests were added or updated.
- [ ] Relevant formatting, Clippy, tests, stubs, and cross-language checks were run.
- [ ] If the public API changed, Rust, Python, Node, `.pyi`, `.d.ts`, and contract tests were updated together.
